### PR TITLE
remove proxy-body-size limit from nginx-ingress

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ install-dependencies: helm
 	$(HELM) get notes registry-cache \
 		|| $(HELM) install registry-cache stable/redis-ha
 	$(HELM) get notes nginx \
-		|| $(HELM) install nginx stable/nginx-ingress
+		|| $(HELM) install nginx stable/nginx-ingress --set-string controller.config.proxy-body-size=0
 	kubectl apply -f config/samples/notary-ingress-service.yaml
 
 # Install local certificate


### PR DESCRIPTION
default proxy-body-size limit the blob upload size

Signed-off-by: Ziming Zhang <zziming@vmware.com>