### PR TITLE
Fix/clair updater and ingress cert

### DIFF
--- a/assets/templates/clair/config.yaml
+++ b/assets/templates/clair/config.yaml
@@ -6,7 +6,7 @@ clair:
     options:
       source: {{ printf "postgresql://%s:%s@%s:%s/%s?sslmode=%s" (env.Getenv "username") (env.Getenv "password") (env.Getenv "host") (env.Getenv "port" "5432") (env.Getenv "database") (env.Getenv "ssl") | quote }}
   updater:
-    interval: 0s
+    interval: 1h
     enabledupdaters:
 {{ env.Getenv "vulnsrc" | data.JSONArray | data.ToYAML | strings.Indent 3 "  " -}}
   api:

--- a/assets/templates/registry/config.yaml
+++ b/assets/templates/registry/config.yaml
@@ -14,6 +14,7 @@ http:
     X-Content-Type-Options: [nosniff]
   net: tcp
   addr: {{ env.Getenv "API_ADDRESS" | quote }}
+  relativeurls: true
   prefix: /
 health:
   storagedriver:

--- a/assets/templates/registry/config.yaml
+++ b/assets/templates/registry/config.yaml
@@ -14,7 +14,6 @@ http:
     X-Content-Type-Options: [nosniff]
   net: tcp
   addr: {{ env.Getenv "API_ADDRESS" | quote }}
-  relativeurls: true
   prefix: /
 health:
   storagedriver:

--- a/controllers/harbor/components/harbor-core/ingresses.go
+++ b/controllers/harbor/components/harbor-core/ingresses.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/goharbor/harbor-operator/pkg/ingress"
 	"github.com/pkg/errors"
 	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,9 +31,15 @@ func (c *HarborCore) GetIngresses(ctx context.Context) []*netv1.Ingress { // nol
 		tls = []netv1.IngressTLS{
 			{
 				SecretName: c.harbor.Spec.TLSSecretName,
+				Hosts: []string{
+					host[0],
+				},
 			},
 		}
 	}
+
+	// Add annotations for cert-manager awareness
+	annotations := ingress.GenerateIngressCertAnnotations(c.harbor.Spec)
 
 	return []*netv1.Ingress{
 		{
@@ -44,6 +51,7 @@ func (c *HarborCore) GetIngresses(ctx context.Context) []*netv1.Ingress { // nol
 					"harbor":   harborName,
 					"operator": operatorName,
 				},
+				Annotations: annotations,
 			},
 			Spec: netv1.IngressSpec{
 				TLS: tls,

--- a/controllers/harbor/components/notary/ingresses.go
+++ b/controllers/harbor/components/notary/ingresses.go
@@ -12,6 +12,7 @@ import (
 
 	goharborv1alpha1 "github.com/goharbor/harbor-operator/api/v1alpha1"
 	"github.com/goharbor/harbor-operator/pkg/factories/application"
+	"github.com/goharbor/harbor-operator/pkg/ingress"
 )
 
 func (n *Notary) GetIngresses(ctx context.Context) []*netv1.Ingress {
@@ -30,9 +31,15 @@ func (n *Notary) GetIngresses(ctx context.Context) []*netv1.Ingress {
 		tls = []netv1.IngressTLS{
 			{
 				SecretName: n.harbor.Spec.TLSSecretName,
+				Hosts: []string{
+					host[0],
+				},
 			},
 		}
 	}
+
+	// Add annotations for cert-manager awareness
+	annotations := ingress.GenerateIngressCertAnnotations(n.harbor.Spec)
 
 	return []*netv1.Ingress{
 		{
@@ -45,6 +52,7 @@ func (n *Notary) GetIngresses(ctx context.Context) []*netv1.Ingress {
 					"operator":                    operatorName,
 					"kubernetes.io/ingress.class": goharborv1alpha1.NotaryName,
 				},
+				Annotations: annotations,
 			},
 			Spec: netv1.IngressSpec{
 				TLS: tls,

--- a/controllers/harbor/components/notary/ingresses.go
+++ b/controllers/harbor/components/notary/ingresses.go
@@ -12,7 +12,6 @@ import (
 
 	goharborv1alpha1 "github.com/goharbor/harbor-operator/api/v1alpha1"
 	"github.com/goharbor/harbor-operator/pkg/factories/application"
-	"github.com/goharbor/harbor-operator/pkg/ingress"
 )
 
 func (n *Notary) GetIngresses(ctx context.Context) []*netv1.Ingress {
@@ -30,16 +29,13 @@ func (n *Notary) GetIngresses(ctx context.Context) []*netv1.Ingress {
 	if u.Scheme == "https" {
 		tls = []netv1.IngressTLS{
 			{
-				SecretName: n.harbor.Spec.TLSSecretName,
+				SecretName: n.harbor.NormalizeComponentName(notaryCertificateName),
 				Hosts: []string{
 					host[0],
 				},
 			},
 		}
 	}
-
-	// Add annotations for cert-manager awareness
-	annotations := ingress.GenerateIngressCertAnnotations(n.harbor.Spec)
 
 	return []*netv1.Ingress{
 		{
@@ -52,7 +48,6 @@ func (n *Notary) GetIngresses(ctx context.Context) []*netv1.Ingress {
 					"operator":                    operatorName,
 					"kubernetes.io/ingress.class": goharborv1alpha1.NotaryName,
 				},
-				Annotations: annotations,
 			},
 			Spec: netv1.IngressSpec{
 				TLS: tls,

--- a/controllers/harbor/components/portal/ingresses.go
+++ b/controllers/harbor/components/portal/ingresses.go
@@ -5,6 +5,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/goharbor/harbor-operator/pkg/ingress"
+
 	"github.com/pkg/errors"
 	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,9 +32,15 @@ func (p *Portal) GetIngresses(ctx context.Context) []*netv1.Ingress { // nolint:
 		tls = []netv1.IngressTLS{
 			{
 				SecretName: p.harbor.Spec.TLSSecretName,
+				Hosts: []string{
+					host[0],
+				},
 			},
 		}
 	}
+
+	// Add annotations for cert-manager awareness
+	annotations := ingress.GenerateIngressCertAnnotations(p.harbor.Spec)
 
 	return []*netv1.Ingress{
 		{
@@ -44,6 +52,7 @@ func (p *Portal) GetIngresses(ctx context.Context) []*netv1.Ingress { // nolint:
 					"harbor":   harborName,
 					"operator": operatorName,
 				},
+				Annotations: annotations,
 			},
 			Spec: netv1.IngressSpec{
 				TLS: tls,

--- a/controllers/harbor/components/registry/certificates.go
+++ b/controllers/harbor/components/registry/certificates.go
@@ -15,6 +15,7 @@ import (
 const (
 	defaultKeyAlgorithm = certv1.RSAKeyAlgorithm
 	defaultKeySize      = 4096
+	registryCertName    = "registry-certificate"
 )
 
 type certificateEncryption struct {
@@ -49,7 +50,7 @@ func (r *Registry) GetCertificates(ctx context.Context) []*certv1.Certificate {
 	return []*certv1.Certificate{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      r.harbor.NormalizeComponentName(goharborv1alpha1.RegistryName),
+				Name:      r.harbor.NormalizeComponentName(registryCertName),
 				Namespace: r.harbor.Namespace,
 				Labels: map[string]string{
 					"app":      goharborv1alpha1.RegistryName,
@@ -60,7 +61,7 @@ func (r *Registry) GetCertificates(ctx context.Context) []*certv1.Certificate {
 			Spec: certv1.CertificateSpec{
 				CommonName:   url,
 				Organization: []string{"Harbor Operator"},
-				SecretName:   r.harbor.NormalizeComponentName(goharborv1alpha1.CertificateName),
+				SecretName:   r.harbor.NormalizeComponentName(registryCertName),
 				KeySize:      encryption.KeySize,
 				KeyAlgorithm: encryption.KeyAlgorithm,
 				// https://github.com/goharbor/harbor/blob/ba4764c61d7da76f584f808f7d16b017db576fb4/src/jobservice/generateCerts.sh#L24-L26

--- a/controllers/harbor/components/registry/certificates.go
+++ b/controllers/harbor/components/registry/certificates.go
@@ -3,13 +3,13 @@ package registry
 import (
 	"context"
 
-	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
-	"github.com/ovh/configstore"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	goharborv1alpha1 "github.com/goharbor/harbor-operator/api/v1alpha1"
 	"github.com/goharbor/harbor-operator/pkg/factories/application"
 	"github.com/goharbor/harbor-operator/pkg/factories/logger"
+	"github.com/goharbor/harbor-operator/pkg/ingress"
+	certv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	"github.com/ovh/configstore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const (
@@ -27,7 +27,10 @@ func (r *Registry) GetCertificates(ctx context.Context) []*certv1.Certificate {
 	operatorName := application.GetName(ctx)
 	harborName := r.harbor.Name
 
-	url := r.harbor.Spec.PublicURL
+	_, h, err := ingress.GetHostAndSchema(r.harbor.Spec.PublicURL)
+	if err != nil {
+		panic(err)
+	}
 
 	encryption := &certificateEncryption{
 		KeySize:      defaultKeySize,
@@ -59,14 +62,14 @@ func (r *Registry) GetCertificates(ctx context.Context) []*certv1.Certificate {
 				},
 			},
 			Spec: certv1.CertificateSpec{
-				CommonName:   url,
+				CommonName:   h,
 				Organization: []string{"Harbor Operator"},
-				SecretName:   r.harbor.NormalizeComponentName(registryCertName),
+				SecretName:   r.harbor.NormalizeComponentName(goharborv1alpha1.CertificateName),
 				KeySize:      encryption.KeySize,
 				KeyAlgorithm: encryption.KeyAlgorithm,
 				// https://github.com/goharbor/harbor/blob/ba4764c61d7da76f584f808f7d16b017db576fb4/src/jobservice/generateCerts.sh#L24-L26
 				KeyEncoding: certv1.PKCS1,
-				DNSNames:    []string{url},
+				DNSNames:    []string{h},
 				IssuerRef:   r.harbor.Spec.CertificateIssuerRef,
 			},
 		},

--- a/controllers/harbor/components/registry/deployments.go
+++ b/controllers/harbor/components/registry/deployments.go
@@ -205,10 +205,12 @@ func (r *Registry) GetDeployments(ctx context.Context) []*appsv1.Deployment { //
 												},
 											},
 										},
-									}, {
-										Name:  "REGISTRY_HTTP_HOST",
-										Value: r.harbor.Spec.PublicURL,
-									}, {
+									},
+									//{
+									//Name:  "REGISTRY_HTTP_HOST",
+									//Value: r.harbor.Spec.PublicURL,
+									//},
+									{
 										Name:  "REGISTRY_AUTH_TOKEN_REALM",
 										Value: fmt.Sprintf("%s/service/token", r.harbor.Spec.PublicURL),
 									}, {
@@ -264,10 +266,11 @@ func (r *Registry) GetDeployments(ctx context.Context) []*appsv1.Deployment { //
 									},
 								},
 								Env: []corev1.EnvVar{
-									{
+									/*{
 										Name:  "REGISTRY_HTTP_HOST",
 										Value: r.harbor.Spec.PublicURL,
-									}, {
+									},*/
+									{
 										Name:  "REGISTRY_AUTH_TOKEN_REALM",
 										Value: fmt.Sprintf("%s/service/token", r.harbor.Spec.PublicURL),
 									}, {

--- a/controllers/harbor/components/registry/ingresses.go
+++ b/controllers/harbor/components/registry/ingresses.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/goharbor/harbor-operator/pkg/ingress"
-
 	"github.com/pkg/errors"
 	netv1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +29,7 @@ func (r *Registry) GetIngresses(ctx context.Context) []*netv1.Ingress { // nolin
 	if u.Scheme == "https" {
 		tls = []netv1.IngressTLS{
 			{
-				SecretName: r.harbor.Spec.TLSSecretName,
+				SecretName: r.harbor.NormalizeComponentName(registryCertName),
 				Hosts: []string{
 					host[0],
 				},
@@ -39,8 +37,7 @@ func (r *Registry) GetIngresses(ctx context.Context) []*netv1.Ingress { // nolin
 		}
 	}
 
-	// Add annotations for cert-manager awareness
-	annotations := ingress.GenerateIngressCertAnnotations(r.harbor.Spec)
+	annotations := make(map[string]string)
 	// resolve 413(Too Large Entity) error when push large image. It only works for NGINX ingress.
 	annotations["nginx.ingress.kubernetes.io/proxy-body-size"] = "0"
 

--- a/controllers/harbor/components/registry/ingresses.go
+++ b/controllers/harbor/components/registry/ingresses.go
@@ -2,36 +2,31 @@ package registry
 
 import (
 	"context"
-	"net/url"
-	"strings"
-
-	"github.com/pkg/errors"
-	netv1 "k8s.io/api/networking/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	goharborv1alpha1 "github.com/goharbor/harbor-operator/api/v1alpha1"
 	"github.com/goharbor/harbor-operator/pkg/factories/application"
+	"github.com/goharbor/harbor-operator/pkg/ingress"
+	netv1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func (r *Registry) GetIngresses(ctx context.Context) []*netv1.Ingress { // nolint:funlen
 	operatorName := application.GetName(ctx)
 	harborName := r.harbor.Name
 
-	u, err := url.Parse(r.harbor.Spec.PublicURL)
+	scheme, h, err := ingress.GetHostAndSchema(r.harbor.Spec.PublicURL)
 	if err != nil {
-		panic(errors.Wrap(err, "invalid url"))
+		panic(err)
 	}
 
-	host := strings.SplitN(u.Host, ":", 1) // nolint:mnd
-
 	var tls []netv1.IngressTLS
-	if u.Scheme == "https" {
+	if scheme == "https" {
 		tls = []netv1.IngressTLS{
 			{
-				SecretName: r.harbor.NormalizeComponentName(registryCertName),
+				SecretName: r.harbor.Spec.TLSSecretName,
 				Hosts: []string{
-					host[0],
+					h,
 				},
 			},
 		}
@@ -57,7 +52,7 @@ func (r *Registry) GetIngresses(ctx context.Context) []*netv1.Ingress { // nolin
 				TLS: tls,
 				Rules: []netv1.IngressRule{
 					{
-						Host: host[0],
+						Host: h,
 						IngressRuleValue: netv1.IngressRuleValue{
 							HTTP: &netv1.HTTPIngressRuleValue{
 								Paths: []netv1.HTTPIngressPath{

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -15,8 +15,12 @@
 package ingress
 
 import (
+	"net/url"
+	"strings"
+
 	"github.com/goharbor/harbor-operator/api/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	"github.com/pkg/errors"
 )
 
 // GenerateIngressCertAnnotations generates the cert-manager related annotations for cert-manager
@@ -37,4 +41,16 @@ func GenerateIngressCertAnnotations(spec v1alpha1.HarborSpec) map[string]string 
 	}
 
 	return annotations
+}
+
+// GetHostAndSchema gets the host domain and schema from the spec
+func GetHostAndSchema(accessURL string) (scheme string, host string, err error) {
+	u, err := url.Parse(accessURL)
+	if err != nil {
+		return "", "", errors.Wrap(err, "invalid public URL")
+	}
+
+	hosts := strings.SplitN(u.Host, ":", 1)
+
+	return u.Scheme, hosts[0], nil
 }

--- a/pkg/ingress/ingress.go
+++ b/pkg/ingress/ingress.go
@@ -1,0 +1,40 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"github.com/goharbor/harbor-operator/api/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+)
+
+// GenerateIngressCertAnnotations generates the cert-manager related annotations for cert-manager
+// identifying the ingress can creating cert for the detected ingress.
+func GenerateIngressCertAnnotations(spec v1alpha1.HarborSpec) map[string]string {
+	// Add annotations for cert-manager awareness
+	annotations := make(map[string]string)
+	issuer := spec.CertificateIssuerRef.Name
+
+	// If name is configured
+	if len(issuer) > 0 {
+		if spec.CertificateIssuerRef.Kind == v1alpha2.ClusterIssuerKind {
+			annotations[v1alpha2.IngressClusterIssuerNameAnnotationKey] = issuer
+		} else {
+			// Treat as default kind: v1alpha2.IssuerKind
+			annotations[v1alpha2.IngressIssuerNameAnnotationKey] = issuer
+		}
+	}
+
+	return annotations
+}


### PR DESCRIPTION
- add cert manager related annotations to the ingresses (core and notary)
- add host info to the ingress TLS part
- remove `REGISTRY_HTTP_HOST ` ENV VAR from registry deployment
- update clair updater interval to `1h` to enable CVE DB updating process

Signed-off-by: Steven Zou <szou@vmware.com>