### PR TITLE
fix(crd) add default namespace in kustomization.yaml

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -2,6 +2,8 @@
 #commonLabels:
 #  someName: someValue
 
+namespace: harbor-operator-ns
+
 bases:
 - ../crd
 - ../manager


### PR DESCRIPTION
add default namespace `harbor-operator` in `config/default/kustomization.yaml`
close #136 