### PR TITLE
feat(services): add health checker interface

### DIFF
--- a/pkg/cluster/controllers/cache/redis.go
+++ b/pkg/cluster/controllers/cache/redis.go
@@ -50,6 +50,10 @@ type RedisController struct {
 	expectCR, actualCR *redisOp.RedisFailover
 }
 
+func (rc *RedisController) HealthChecker() lcm.HealthChecker {
+	panic("implement me")
+}
+
 // Apply creates/updates/scales the resources, like kubernetes apply operation.
 func (rc *RedisController) Apply(ctx context.Context, cluster *v1alpha2.HarborCluster) (*lcm.CRStatus, error) {
 	rc.Client.WithContext(ctx)

--- a/pkg/cluster/controllers/database/postgresql.go
+++ b/pkg/cluster/controllers/database/postgresql.go
@@ -37,6 +37,10 @@ type Connect struct {
 	Database string
 }
 
+func (p *PostgreSQLController) HealthChecker() lcm.HealthChecker {
+	panic("implement me")
+}
+
 func (p *PostgreSQLController) Apply(ctx context.Context, harborcluster *v1alpha2.HarborCluster) (*lcm.CRStatus, error) {
 
 	p.Client.WithContext(ctx)

--- a/pkg/cluster/controllers/storage/minio.go
+++ b/pkg/cluster/controllers/storage/minio.go
@@ -49,6 +49,10 @@ type MinIOController struct {
 	MinioClient           Minio
 }
 
+func (m *MinIOController) HealthChecker() lcm.HealthChecker {
+	panic("implement me")
+}
+
 var (
 	HarborClusterMinIOGVK = schema.GroupVersionKind{
 		Group:   minio.SchemeGroupVersion.Group,

--- a/pkg/cluster/lcm/health.go
+++ b/pkg/cluster/lcm/health.go
@@ -1,0 +1,106 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lcm
+
+import "context"
+
+const (
+	Healthy   HealthStatus = "healthy"
+	UnHealthy HealthStatus = "unhealthy"
+	Unknown   HealthStatus = "unknown"
+)
+
+type HealthStatus string
+
+// HealthChecker defines health check methods to check the health status of the related services
+type HealthChecker interface {
+	// CheckHealth checks the health of the specified service, including:
+	// database postgresql /
+	// cache redis /
+	// storage minIO /
+	CheckHealth(ctx context.Context, svc *ServiceConfig, options ...Option) (*CheckResponse, error)
+}
+
+// ServiceConfig contains the relevant service configurations that can be used to do health check
+type ServiceConfig struct {
+	// Endpoint of the service
+	// Required
+	Endpoint *Endpoint
+	// Credentials used to connect service
+	Credentials *Credentials
+}
+
+// Endpoint of the service
+type Endpoint struct {
+	Host string
+	Port uint
+}
+
+// Credentials for connecting to the services
+type Credentials struct {
+	// Access key or username
+	// Optional
+	AccessKey string
+	// Access secret or password
+	AccessSecret string
+}
+
+// CheckResponse represents the response returned by the health check method
+type CheckResponse struct {
+	Status HealthStatus
+
+	// Extra message if needed
+	// Optional
+	Message string
+}
+
+// CheckOptions keep options for doing health checking
+type CheckOptions struct {
+	// Enable SSL mode
+	// Applicable for Postgresql
+	SSLMode bool
+
+	// Whether connecting to Redis with sentinel mode
+	// Applicable for Redis
+	Sentinel bool
+
+	// Name of the storage driver
+	// Applicable for minIO
+	StorageDriver string
+}
+
+// Option with function way
+type Option func(options *CheckOptions)
+
+// WithSSL sets ssl mode option
+func WithSSL(sslMode bool) Option {
+	return func(options *CheckOptions) {
+		options.SSLMode = sslMode
+	}
+}
+
+// WithSentinel sets sentinel mode
+func WithSentinel(sentinel bool) Option {
+	return func(options *CheckOptions) {
+		options.Sentinel = sentinel
+	}
+}
+
+// WithStorage sets the storage driver
+func WithStorage(driver string) Option {
+	return func(options *CheckOptions) {
+		options.StorageDriver = driver
+	}
+}

--- a/pkg/cluster/lcm/lcm.go
+++ b/pkg/cluster/lcm/lcm.go
@@ -26,6 +26,10 @@ type Controller interface {
 
 	// Upgrade the specified resource to the given version.
 	Upgrade(ctx context.Context, harborcluster *v1alpha2.HarborCluster) (*CRStatus, error)
+
+	// HealthChecker returns a health checker implementation for checking the health status of the service managed
+	// by this controller.
+	HealthChecker() HealthChecker
 }
 
 type CRStatus struct {


### PR DESCRIPTION
Signed-off-by: Steven Zou <szou@vmware.com>

- add health checker interface
- add new checker get method in the lcm controller interface

fix #212 