### PR TITLE
fix(notary) signer alias key should use upper case envrionment

### DIFF
--- a/controllers/goharbor/harbor/notarysigner.go
+++ b/controllers/goharbor/harbor/notarysigner.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	goharborv1alpha2 "github.com/goharbor/harbor-operator/apis/goharbor.io/v1alpha2"
@@ -131,8 +132,7 @@ func (r *Reconciler) GetNotarySignerEncryptionKey(ctx context.Context, harbor *g
 		},
 		Type: harbormetav1.SecretTypeNotarySignerAliases,
 		StringData: map[string]string{
-			harbormetav1.DefaultAliasSecretKey: "defaultalias",
-			"defaultalias":                     secret,
+			strings.ToUpper(harbormetav1.DefaultAliasSecretKey): secret,
 		},
 	}, nil
 }


### PR DESCRIPTION
close #193 

the default alias key for notary signer should be upper case

reference https://github.com/theupdateframework/notary/blob/84287fd8df4f172c9a8289641cdfa355fc86989d/cmd/notary-signer/config.go#L88