### PR TITLE
Refactor/harbor ctrl

### DIFF
--- a/apis/goharbor.io/v1alpha2/harbor_types.go
+++ b/apis/goharbor.io/v1alpha2/harbor_types.go
@@ -305,6 +305,10 @@ func (r *HarborStorageImageChartStorageSpec) ProviderName() string {
 }
 
 func (r *HarborStorageImageChartStorageSpec) Validate() error {
+	if r == nil {
+		return ErrNoStorageConfiguration
+	}
+
 	found := 0
 
 	if r.FileSystem != nil {

--- a/controllers/goharbor/harborcluster/service_mgr.go
+++ b/controllers/goharbor/harborcluster/service_mgr.go
@@ -1,0 +1,225 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harborcluster
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/goharbor/harbor-operator/apis/goharbor.io/v1alpha2"
+	"github.com/goharbor/harbor-operator/pkg/cluster/controllers/harbor"
+	"github.com/goharbor/harbor-operator/pkg/cluster/lcm"
+	v1 "k8s.io/api/core/v1"
+)
+
+// ServiceManager is designed to maintain the dependent services of the cluster.
+type ServiceManager struct {
+	ctx             context.Context
+	cluster         *v1alpha2.HarborCluster
+	component       v1alpha2.Component
+	st              *status
+	ctrl            lcm.Controller
+	svcConfigGetter svcConfigGetter
+	harborCtrl      *harbor.Controller
+}
+
+// NewServiceManager constructs a new service manager for the specified component.
+func NewServiceManager(component v1alpha2.Component) *ServiceManager {
+	return &ServiceManager{
+		component: component,
+	}
+}
+
+// WithContext bind a context.
+func (s *ServiceManager) WithContext(ctx context.Context) *ServiceManager {
+	s.ctx = ctx
+
+	return s
+}
+
+// From which spec.
+func (s *ServiceManager) From(cluster *v1alpha2.HarborCluster) *ServiceManager {
+	s.cluster = cluster
+
+	return s
+}
+
+// For the harbor.
+func (s *ServiceManager) For(harborCtrl *harbor.Controller) *ServiceManager {
+	s.harborCtrl = harborCtrl
+
+	return s
+}
+
+// TrackedBy by which status object.
+func (s *ServiceManager) TrackedBy(st *status) *ServiceManager {
+	s.st = st
+
+	return s
+}
+
+// Use which ctrl.
+func (s *ServiceManager) Use(ctrl lcm.Controller) *ServiceManager {
+	s.ctrl = ctrl
+
+	return s
+}
+
+// WithConfig bind service configuration getter func.
+func (s *ServiceManager) WithConfig(svcCfgGetter svcConfigGetter) *ServiceManager {
+	s.svcConfigGetter = svcCfgGetter
+
+	return s
+}
+
+// Apply changes.
+func (s *ServiceManager) Apply() error {
+	if err := s.validate(); err != nil {
+		return err
+	}
+
+	var (
+		status        *lcm.CRStatus
+		err           error
+		conditionType = s.conditionType()
+	)
+
+	defer func() {
+		// Add condition
+		if status != nil {
+			// Here just add condition update to the status, the real update happens outside
+			s.st.UpdateCondition(conditionType, status.Condition)
+			// Assign to harbor ctrl for the reconcile of cluster
+			if err == nil {
+				s.harborCtrl.WithDependency(s.component, status)
+			}
+		}
+	}()
+
+	// The validating webhook validates the spec and either incluster or external can be configured.
+	useInCluster := true
+
+	switch s.component {
+	case v1alpha2.ComponentCache:
+		if s.cluster.Spec.InClusterCache == nil {
+			useInCluster = false
+		}
+	case v1alpha2.ComponentDatabase:
+		if s.cluster.Spec.InClusterDatabase == nil {
+			useInCluster = false
+		}
+	case v1alpha2.ComponentStorage:
+		if s.cluster.Spec.InClusterStorage == nil {
+			useInCluster = false
+		}
+		// Only for wsl check
+	case v1alpha2.ComponentHarbor:
+		return fmt.Errorf("%s is not supported", s.component)
+	default:
+		// Should not happen, just in case
+		return fmt.Errorf("unrecognized component: %s", s.component)
+	}
+
+	if s.ctx == nil {
+		s.ctx = context.TODO()
+	}
+
+	if useInCluster {
+		// Use incluster
+		status, err = s.ctrl.Apply(s.ctx, s.cluster)
+		if err != nil {
+			return err
+		}
+	} else {
+		// Default is ready
+		status = &lcm.CRStatus{
+			Condition: v1alpha2.HarborClusterCondition{
+				Type:   conditionType,
+				Status: v1.ConditionTrue,
+			},
+		}
+
+		// Use external
+		svcCfg, options, err := s.svcConfigGetter(s.ctx, s.cluster)
+		if err != nil {
+			status.WithStatus(v1.ConditionFalse).
+				WithMessage("failed to get service configuration").
+				WithReason(err.Error())
+
+			return err
+		}
+
+		res, err := s.ctrl.HealthChecker().CheckHealth(s.ctx, svcCfg, options...)
+		if err != nil {
+			status.WithStatus(v1.ConditionFalse).
+				WithMessage("failed to check service health").
+				WithReason(err.Error())
+
+			return err
+		}
+
+		status.WithMessage(res.Message)
+	}
+
+	return nil
+}
+
+func (s *ServiceManager) validate() error {
+	if s.component != v1alpha2.ComponentCache &&
+		s.component != v1alpha2.ComponentStorage &&
+		s.component != v1alpha2.ComponentDatabase {
+		return fmt.Errorf("invalid service component: %s", s.component)
+	}
+
+	if s.cluster == nil {
+		return errors.New("missing cluster spec")
+	}
+
+	if s.ctrl == nil {
+		return errors.New("missing lcm controller")
+	}
+
+	if s.st == nil {
+		return errors.New("missing status")
+	}
+
+	if s.svcConfigGetter == nil {
+		return errors.New("missing svc config getter")
+	}
+
+	if s.harborCtrl == nil {
+		return errors.New("missing harbor ctrl")
+	}
+
+	return nil
+}
+
+func (s *ServiceManager) conditionType() v1alpha2.HarborClusterConditionType {
+	switch s.component {
+	case v1alpha2.ComponentStorage:
+		return v1alpha2.StorageReady
+	case v1alpha2.ComponentDatabase:
+		return v1alpha2.DatabaseReady
+	case v1alpha2.ComponentCache:
+		return v1alpha2.CacheReady
+		// Only for wsl check
+	case v1alpha2.ComponentHarbor:
+		return v1alpha2.ServiceReady
+	default:
+		// Should not reach here
+		return ""
+	}
+}

--- a/controllers/goharbor/harborcluster/status.go
+++ b/controllers/goharbor/harborcluster/status.go
@@ -149,35 +149,8 @@ func (s *status) WithLog(logger logr.Logger) *status {
 	return s
 }
 
-// UpdateCache updates cache status.
-func (s *status) UpdateCache(c goharborv1.HarborClusterCondition) *status {
-	s.updateCondition(goharborv1.CacheReady, c)
-
-	return s
-}
-
-// UpdateDatabase updates database status.
-func (s *status) UpdateDatabase(c goharborv1.HarborClusterCondition) *status {
-	s.updateCondition(goharborv1.DatabaseReady, c)
-
-	return s
-}
-
-// UpdateStorage updates storage status.
-func (s *status) UpdateStorage(c goharborv1.HarborClusterCondition) *status {
-	s.updateCondition(goharborv1.StorageReady, c)
-
-	return s
-}
-
-// UpdateHarbor updates Harbor status.
-func (s *status) UpdateHarbor(c goharborv1.HarborClusterCondition) *status {
-	s.updateCondition(goharborv1.ServiceReady, c)
-
-	return s
-}
-
-func (s *status) updateCondition(ct goharborv1.HarborClusterConditionType, c goharborv1.HarborClusterCondition) {
+// UpdateCondition adds condition update of the specified service to the status object.
+func (s *status) UpdateCondition(ct goharborv1.HarborClusterConditionType, c goharborv1.HarborClusterCondition) {
 	s.locker.Lock()
 	defer s.locker.Unlock()
 

--- a/controllers/goharbor/harborcluster/svc_config.go
+++ b/controllers/goharbor/harborcluster/svc_config.go
@@ -1,0 +1,40 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harborcluster
+
+import (
+	"context"
+
+	"github.com/goharbor/harbor-operator/apis/goharbor.io/v1alpha2"
+	"github.com/goharbor/harbor-operator/pkg/cluster/lcm"
+)
+
+// svcConfigGetter is used to get the required access data from the cluster spec for health checking.
+type svcConfigGetter func(ctx context.Context, cluster *v1alpha2.HarborCluster) (*lcm.ServiceConfig, []lcm.Option, error)
+
+// cacheConfigGetter is for getting configurations of cache service.
+func cacheConfigGetter(ctx context.Context, cluster *v1alpha2.HarborCluster) (*lcm.ServiceConfig, []lcm.Option, error) {
+	return nil, nil, nil
+}
+
+// dbConfigGetter is for getting configurations of database service.
+func dbConfigGetter(ctx context.Context, cluster *v1alpha2.HarborCluster) (*lcm.ServiceConfig, []lcm.Option, error) {
+	return nil, nil, nil
+}
+
+// storageConfigGetter is for getting configurations of storage service.
+func storageConfigGetter(ctx context.Context, cluster *v1alpha2.HarborCluster) (*lcm.ServiceConfig, []lcm.Option, error) {
+	return nil, nil, nil
+}

--- a/pkg/cluster/controllers/harbor/cr_status.go
+++ b/pkg/cluster/controllers/harbor/cr_status.go
@@ -20,15 +20,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-// harborReadyStatus indicates harbor (CR) is ready
+// harborReadyStatus indicates harbor (CR) is ready.
 var harborReadyStatus = lcm.New(v1alpha2.ServiceReady).WithStatus(corev1.ConditionTrue)
 
-// harborNotReadyStatus indicates harbor (CR) is not ready
+// harborNotReadyStatus indicates harbor (CR) is not ready.
 var harborNotReadyStatus = func(reason, message string) *lcm.CRStatus {
 	return lcm.New(v1alpha2.ServiceReady).WithStatus(corev1.ConditionFalse).WithReason(reason).WithMessage(message)
 }
 
-// harborUnknownStatus indicates status of harbor (CR) is unknown
+// harborUnknownStatus indicates status of harbor (CR) is unknown.
 var harborUnknownStatus = func(reason, message string) *lcm.CRStatus {
 	return lcm.New(v1alpha2.ServiceReady).WithStatus(corev1.ConditionUnknown).WithReason(reason).WithMessage(message)
 }

--- a/pkg/cluster/controllers/harbor/cr_status.go
+++ b/pkg/cluster/controllers/harbor/cr_status.go
@@ -1,0 +1,34 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package harbor
+
+import (
+	"github.com/goharbor/harbor-operator/apis/goharbor.io/v1alpha2"
+	"github.com/goharbor/harbor-operator/pkg/cluster/lcm"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// harborReadyStatus indicates harbor (CR) is ready
+var harborReadyStatus = lcm.New(v1alpha2.ServiceReady).WithStatus(corev1.ConditionTrue)
+
+// harborNotReadyStatus indicates harbor (CR) is not ready
+var harborNotReadyStatus = func(reason, message string) *lcm.CRStatus {
+	return lcm.New(v1alpha2.ServiceReady).WithStatus(corev1.ConditionFalse).WithReason(reason).WithMessage(message)
+}
+
+// harborUnknownStatus indicates status of harbor (CR) is unknown
+var harborUnknownStatus = func(reason, message string) *lcm.CRStatus {
+	return lcm.New(v1alpha2.ServiceReady).WithStatus(corev1.ConditionUnknown).WithReason(reason).WithMessage(message)
+}

--- a/pkg/cluster/controllers/harbor/harbor.go
+++ b/pkg/cluster/controllers/harbor/harbor.go
@@ -24,6 +24,7 @@ type Controller struct {
 	ComponentToCRStatus *sync.Map
 }
 
+// Apply Harbor instance.
 func (harbor *Controller) Apply(ctx context.Context, harborcluster *v1alpha2.HarborCluster) (*lcm.CRStatus, error) {
 	harborCR := &v1alpha2.Harbor{}
 
@@ -59,8 +60,8 @@ func (harbor *Controller) Apply(ctx context.Context, harborcluster *v1alpha2.Har
 	if !same {
 		// Spec is changed, do update now
 		harbor.Log.Info("update harbor service", "name", nsdName)
-		harborCR.Spec = desiredCR.Spec
 
+		harborCR.Spec = desiredCR.Spec
 		if err := harbor.KubeClient.Update(harborCR); err != nil {
 			return harborNotReadyStatus(UpdateHarborCRError, err.Error()), err
 		}


### PR DESCRIPTION
refactor(ctrl):update harbor CR ctrl

- do comparison before the update
- refactor status objects
- introduce `equality.Semantic` to do k8s object spec comparison

refactor(reconciler):update the logic of cluster ctrl

- introduce a service manager to handle all the dependent services apply the process
- add service config getter func template for getting info to do a health check
- update the methods of cluster status handler


Signed-off-by: Steven Zou <szou@vmware.com>