### PR TITLE
refactor(controller): one method to add mutable and immutable secret

### DIFF
--- a/controllers/goharbor/harbor/core.go
+++ b/controllers/goharbor/harbor/core.go
@@ -72,7 +72,7 @@ func (r *Reconciler) AddCoreAdminPassword(ctx context.Context, harbor *goharborv
 		return nil, errors.Wrap(err, "get")
 	}
 
-	adminPasswordRes, err := r.AddImmutableSecretToManage(ctx, adminPassword)
+	adminPasswordRes, err := r.AddSecretToManage(ctx, adminPassword)
 	if err != nil {
 		return nil, errors.Wrap(err, "add")
 	}

--- a/controllers/goharbor/harbor/notarysigner.go
+++ b/controllers/goharbor/harbor/notarysigner.go
@@ -102,7 +102,7 @@ func (r *Reconciler) AddNotarySignerEncryptionKey(ctx context.Context, harbor *g
 		return nil, errors.Wrap(err, "get")
 	}
 
-	secretRes, err := r.Controller.AddImmutableSecretToManage(ctx, secret)
+	secretRes, err := r.Controller.AddSecretToManage(ctx, secret)
 	if err != nil {
 		return nil, errors.Wrap(err, "add")
 	}

--- a/pkg/controller/resource.go
+++ b/pkg/controller/resource.go
@@ -276,27 +276,13 @@ func (c *Controller) AddSecretToManage(ctx context.Context, resource *corev1.Sec
 		return nil, nil
 	}
 
-	res := &Resource{
-		mutable:   mutation.NewSecret(c.GlobalMutateFn(ctx), true, false),
-		checkable: statuscheck.True,
-		resource:  resource,
-	}
-
-	g := sgraph.Get(ctx)
-	if g == nil {
-		return nil, errors.Errorf("no graph in current context")
-	}
-
-	return res, g.AddResource(ctx, res, dependencies, c.ProcessFunc(ctx, resource, dependencies...))
-}
-
-func (c *Controller) AddImmutableSecretToManage(ctx context.Context, resource *corev1.Secret, dependencies ...graph.Resource) (graph.Resource, error) {
-	if resource == nil {
-		return nil, nil
+	override := true
+	if resource.Immutable != nil && *resource.Immutable {
+		override = false
 	}
 
 	res := &Resource{
-		mutable:   mutation.NewSecret(c.GlobalMutateFn(ctx), false, false),
+		mutable:   mutation.NewSecret(c.GlobalMutateFn(ctx), override, false),
 		checkable: statuscheck.True,
 		resource:  resource,
 	}


### PR DESCRIPTION
Update `AddSecretToManage` method to support both mutable and immutable
secret, and remove `AddImmutableSecretToManage` method.

Signed-off-by: He Weiwei <hweiwei@vmware.com>