### PR TITLE
fix spec.imageChartStorage.filesystem.chartPersistentVolume optional

### DIFF
--- a/apis/goharbor.io/v1alpha2/harbor_types.go
+++ b/apis/goharbor.io/v1alpha2/harbor_types.go
@@ -335,7 +335,7 @@ func (r *HarborStorageImageChartStorageSpec) Validate() error {
 
 type HarborStorageImageChartStorageFileSystemSpec struct {
 	// +kubebuilder:validation:Optional
-	ChartPersistentVolume *HarborStoragePersistentVolumeSpec `json:"chartPersistentVolume"`
+	ChartPersistentVolume *HarborStoragePersistentVolumeSpec `json:"chartPersistentVolume,omitempty"`
 
 	// +kubebuilder:validation:Required
 	RegistryPersistentVolume HarborStorageRegistryPersistentVolumeSpec `json:"registryPersistentVolume"`


### PR DESCRIPTION
close #318 
chartPersistentVolume should be optional when not install chartmuseum