### PR TITLE
feat(database): add max_connections for the incluster postgres

### DIFF
--- a/controllers/goharbor/core/deployments.go
+++ b/controllers/goharbor/core/deployments.go
@@ -42,6 +42,8 @@ const (
 	TokenStoragePath                      = ConfigPath + "/token"
 	ServiceTokenCertificateVolumeName     = "token-service-private-key"
 	ServiceTokenCertificatePath           = ConfigPath + "/private_key.pem"
+	PostGreSQLMaxOpenConns                = "1000"
+	PostGreSQLMaxIdleConns                = "50"
 )
 
 const (
@@ -161,13 +163,15 @@ func (r *Reconciler) GetDeployment(ctx context.Context, core *goharborv1alpha2.C
 				},
 			},
 		}),
-		common.PostGreSQLDatabase:    harbor.Value(core.Spec.Database.Database),
-		common.CoreURL:               harbor.Value(coreLocalURL),
-		common.CoreLocalURL:          harbor.Value(coreLocalURL),
-		common.RegistryControllerURL: harbor.Value(core.Spec.Components.Registry.ControllerURL),
-		common.RegistryURL:           harbor.Value(core.Spec.Components.Registry.RegistryURL),
-		common.JobServiceURL:         harbor.Value(core.Spec.Components.JobService.URL),
-		common.TokenServiceURL:       harbor.Value(core.Spec.Components.TokenService.URL),
+		common.PostGreSQLDatabase:     harbor.Value(core.Spec.Database.Database),
+		common.PostGreSQLMaxOpenConns: harbor.Value(PostGreSQLMaxOpenConns),
+		common.PostGreSQLMaxIdleConns: harbor.Value(PostGreSQLMaxIdleConns),
+		common.CoreURL:                harbor.Value(coreLocalURL),
+		common.CoreLocalURL:           harbor.Value(coreLocalURL),
+		common.RegistryControllerURL:  harbor.Value(core.Spec.Components.Registry.ControllerURL),
+		common.RegistryURL:            harbor.Value(core.Spec.Components.Registry.RegistryURL),
+		common.JobServiceURL:          harbor.Value(core.Spec.Components.JobService.URL),
+		common.TokenServiceURL:        harbor.Value(core.Spec.Components.TokenService.URL),
 		common.AdminInitialPassword: harbor.ValueFrom(corev1.EnvVarSource{
 			SecretKeyRef: &corev1.SecretKeySelector{
 				Key:      harbormetav1.SharedSecretKey,

--- a/pkg/cluster/controllers/database/api/postgresql_type.go
+++ b/pkg/cluster/controllers/database/api/postgresql_type.go
@@ -114,7 +114,8 @@ type AdditionalVolume struct {
 
 // PostgresqlParam describes PostgreSQL version and pairs of configuration parameter name - values.
 type PostgresqlParam struct {
-	PgVersion string `json:"version"`
+	PgVersion  string            `json:"version"`
+	Parameters map[string]string `json:"parameters,omitempty"`
 }
 
 // ResourceDescription describes CPU and memory resources defined for a cluster.

--- a/pkg/cluster/controllers/database/generate.go
+++ b/pkg/cluster/controllers/database/generate.go
@@ -49,7 +49,8 @@ func (p *PostgreSQLController) GetPostgresCR() (*unstructured.Unstructured, erro
 			Patroni:           GetPatron(),
 			Databases:         databases,
 			PostgresqlParam: api.PostgresqlParam{
-				PgVersion: version,
+				PgVersion:  version,
+				Parameters: p.GetPostgreParameters(),
 			},
 			Resources:   resource,
 			DockerImage: p.GetImage(),


### PR DESCRIPTION
1. Set the max_connections to 1024 for the incluster postgres database.
2. Limit max_open_conns and max_idle_conns for the core component.

Closes #382

Signed-off-by: He Weiwei <hweiwei@vmware.com>