### PR TITLE
fix: inject github token from operator to trivy spec

### DIFF
--- a/.github/kind.yaml
+++ b/.github/kind.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    nodeRegistration:
+      kubeletExtraArgs:
+        node-labels: "ingress-ready=true"
+  extraPortMappings:
+  - containerPort: 80
+    hostPort: 80
+    protocol: TCP
+  - containerPort: 443
+    hostPort: 443
+    protocol: TCP
+- role: worker

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
   docker-lint:
     runs-on: ubuntu-latest
     name: 'dockerfile: lint'
-    steps: 
+    steps:
     - uses: actions/checkout@v2
     - run: make docker-lint
 
@@ -64,21 +64,18 @@ jobs:
     env:
       USE_EXISTING_CLUSTER: true
     steps:
+      - uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
           go-version: 1.14
 
       - name: Install Kubernetes
-        run: |
-          which kind || (curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.9.0/kind-$(uname)-amd64; sudo install kind /usr/local/bin/)
-          cat <<EOF | kind create cluster --name harbor --config=-
-          kind: Cluster
-          apiVersion: kind.x-k8s.io/v1alpha4
-          nodes:
-          - role: control-plane
-          - role: worker
-          - role: worker
-          EOF
+        uses: helm/kind-action@v1.1.0
+        with:
+          version: v0.9.0
+          cluster_name: harbor
+          config: .github/kind.yaml
 
       - name: Install CertManager
         run: |
@@ -86,8 +83,6 @@ jobs:
           kubectl apply -f "https://github.com/jetstack/cert-manager/releases/download/v0.16.1/cert-manager.yaml"
           sleep 5
           time kubectl -n cert-manager wait --for=condition=Available deployment --all --timeout 300s
-
-      - uses: actions/checkout@v2
 
       - name: go tests
         run: |
@@ -114,20 +109,19 @@ jobs:
         - "1.19.1"
 
     steps:
+    - uses: actions/checkout@v2
+
     - uses: actions/setup-go@v2
       with:
         go-version: 1.14
 
     - name: Install Kubernetes v${{ matrix.k8sVersion }}
-      run: |
-        which kind || (curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.9.0/kind-$(uname)-amd64; sudo install kind /usr/local/bin/)
-        cat <<EOF | kind create cluster --name harbor --image=kindest/node:v${{ matrix.k8sVersion }} --config=-
-        kind: Cluster
-        apiVersion: kind.x-k8s.io/v1alpha4
-        nodes:
-        - role: control-plane
-        - role: worker
-        EOF
+      uses: helm/kind-action@v1.1.0
+      with:
+        version: v0.9.0
+        node_image: kindest/node:v${{ matrix.k8sVersion }}
+        cluster_name: harbor
+        config: .github/kind.yaml
 
     - name: Install CertManager v${{ matrix.certManager }}
       run: |
@@ -139,11 +133,8 @@ jobs:
 
     - name: Install Ingress
       run: |
-        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.35.0/deploy/static/provider/baremetal/deploy.yaml
-        sleep 5
-        time kubectl -n ingress-nginx wait --for=condition=Available deployment --all --timeout 300s
-
-    - uses: actions/checkout@v2
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.35.0/deploy/static/provider/kind/deploy.yaml
+        time kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=300s
 
     - name: build harbor-operator
       run: |
@@ -152,10 +143,10 @@ jobs:
 
     - name: install harbor-operator
       run: |
-        set -ex
         cd manifests/cluster
+        kustomize edit add secret github-token --disableNameSuffixHash --from-literal=GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        kustomize edit add patch --path patch/github-token.yaml
         kustomize edit set image goharbor/harbor-operator=harbor-operator:dev_test
-        git diff
         kustomize build | kubectl apply -f -
 
         if ! time kubectl -n harbor-operator-ns wait --for=condition=Available deployment --all --timeout 300s; then
@@ -201,9 +192,6 @@ jobs:
     - name: test harbor
       run: |
         set -ex
-        sudo kubectl get -n ingress-nginx service/ingress-nginx-controller
-        sudo kubectl port-forward -n ingress-nginx service/ingress-nginx-controller 443:443 80:80 --address=0.0.0.0 &
-        sleep 10
         curl https://$CORE_HOST/api/v2.0/systeminfo -i -k -f
         sudo mkdir -p /etc/docker/certs.d/$CORE_HOST
         kubectl -n cluster-sample-ns get secret sample-public-certificate -o jsonpath='{.data.ca\.crt}' \
@@ -247,7 +235,7 @@ jobs:
   operator-kubernetes-resources:
     runs-on: ubuntu-latest
     name: 'kubernetes_resources: ./config/rbac'
-    steps: 
+    steps:
     - uses: actions/setup-go@v2
       with:
         go-version: 1.14
@@ -262,7 +250,7 @@ jobs:
   samples-kubernetes-resources:
     runs-on: ubuntu-latest
     name: 'kubernetes_resources: ./config/samples'
-    steps: 
+    steps:
     - uses: actions/checkout@v2
     - uses: azure/k8s-bake@v1
       with:
@@ -281,7 +269,7 @@ jobs:
         path:
         - samples/harbor
         - samples/harbor-full
-    steps: 
+    steps:
     - uses: actions/checkout@v2
     - uses: azure/k8s-bake@v1
       with:

--- a/controllers/goharbor/harbor/harbor_suite_test.go
+++ b/controllers/goharbor/harbor/harbor_suite_test.go
@@ -1,10 +1,22 @@
 package harbor_test
 
 import (
+	"context"
+	"io/ioutil"
+	"strings"
 	"testing"
 
+	goharborv1alpha2 "github.com/goharbor/harbor-operator/apis/goharbor.io/v1alpha2"
+	"github.com/goharbor/harbor-operator/controllers"
+	"github.com/goharbor/harbor-operator/controllers/goharbor/harbor"
+	"github.com/goharbor/harbor-operator/pkg/config"
+	"github.com/goharbor/harbor-operator/pkg/factories/application"
+	"github.com/goharbor/harbor-operator/pkg/factories/logger"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 func TestHarbor(t *testing.T) {
@@ -12,4 +24,54 @@ func TestHarbor(t *testing.T) {
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Harbor Suite")
+}
+
+func fileString(filePath string) string {
+	content, err := ioutil.ReadFile(filePath)
+	Expect(err).NotTo(HaveOccurred())
+
+	return strings.TrimSpace(string(content))
+}
+
+func makeContext() context.Context {
+	ctx := logger.Context(zap.LoggerTo(GinkgoWriter, true))
+	application.SetName(&ctx, "operator")
+	application.SetVersion(&ctx, "dev")
+
+	return ctx
+}
+
+func makeReconciler(ctx context.Context) *harbor.Reconciler {
+	name := controllers.Harbor.String()
+	configStore := config.NewConfigWithDefaults()
+	configStore.Env(name)
+	configStore.InitFromEnvironment()
+
+	h, err := harbor.New(ctx, name, configStore)
+	Expect(err).NotTo(HaveOccurred())
+
+	r := h.(*harbor.Reconciler)
+
+	sch := runtime.NewScheme()
+	_ = goharborv1alpha2.AddToScheme(sch)
+
+	r.Controller.Scheme = sch
+
+	return r
+}
+
+func getSpec(file string) *goharborv1alpha2.Harbor {
+	input := fileString(file)
+
+	sch := runtime.NewScheme()
+	_ = goharborv1alpha2.AddToScheme(sch)
+	decoder := serializer.NewCodecFactory(sch).UniversalDeserializer()
+
+	obj, _, err := decoder.Decode([]byte(input), nil, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	h, ok := obj.(*goharborv1alpha2.Harbor)
+	Expect(ok).To(BeTrue())
+
+	return h
 }

--- a/controllers/goharbor/harbor/manifests/trivy/default-expected.yaml
+++ b/controllers/goharbor/harbor/manifests/trivy/default-expected.yaml
@@ -1,0 +1,31 @@
+apiVersion: goharbor.io/v1alpha2
+kind: Trivy
+metadata:
+  annotations:
+    harbor.goharbor.io/version: ""
+  creationTimestamp: null
+  name: example-harbor
+  namespace: default
+spec:
+  log: {}
+  redis:
+    database: 5
+    host: 127.0.0.1
+    jobs: {}
+    pool: {}
+    port: 3306
+  resources: {}
+  server: {}
+  storage:
+    cache:
+      volumeSource:
+        emptyDir: {}
+    reports:
+      volumeSource:
+        emptyDir: {}
+  update:
+    skip: false
+status:
+  conditions: []
+  message: ""
+  status: ""

--- a/controllers/goharbor/harbor/manifests/trivy/default.yaml
+++ b/controllers/goharbor/harbor/manifests/trivy/default.yaml
@@ -1,0 +1,10 @@
+apiVersion: goharbor.io/v1alpha2
+kind: Harbor
+metadata:
+  name: example
+  namespace: default
+spec:
+  trivy: {}
+  redis:
+    host: 127.0.0.1
+    port: 3306

--- a/controllers/goharbor/harbor/manifests/trivy/expose-core-with-tls-expected.yaml
+++ b/controllers/goharbor/harbor/manifests/trivy/expose-core-with-tls-expected.yaml
@@ -1,0 +1,33 @@
+apiVersion: goharbor.io/v1alpha2
+kind: Trivy
+metadata:
+  annotations:
+    harbor.goharbor.io/version: ""
+  creationTimestamp: null
+  name: example-harbor
+  namespace: default
+spec:
+  log: {}
+  redis:
+    database: 5
+    host: 127.0.0.1
+    jobs: {}
+    pool: {}
+    port: 3306
+  resources: {}
+  server:
+    tokenServiceCertificateAuthorityRefs:
+    - harbor-tls
+  storage:
+    cache:
+      volumeSource:
+        emptyDir: {}
+    reports:
+      volumeSource:
+        emptyDir: {}
+  update:
+    skip: false
+status:
+  conditions: []
+  message: ""
+  status: ""

--- a/controllers/goharbor/harbor/manifests/trivy/expose-core-with-tls.yaml
+++ b/controllers/goharbor/harbor/manifests/trivy/expose-core-with-tls.yaml
@@ -1,0 +1,14 @@
+apiVersion: goharbor.io/v1alpha2
+kind: Harbor
+metadata:
+  name: example
+  namespace: default
+spec:
+  expose:
+    core:
+      tls:
+        certificateRef: harbor-tls
+  trivy: {}
+  redis:
+    host: 127.0.0.1
+    port: 3306

--- a/controllers/goharbor/harbor/manifests/trivy/github-token-expected.yaml
+++ b/controllers/goharbor/harbor/manifests/trivy/github-token-expected.yaml
@@ -1,0 +1,32 @@
+apiVersion: goharbor.io/v1alpha2
+kind: Trivy
+metadata:
+  annotations:
+    harbor.goharbor.io/version: ""
+  creationTimestamp: null
+  name: example-harbor
+  namespace: default
+spec:
+  log: {}
+  redis:
+    database: 5
+    host: 127.0.0.1
+    jobs: {}
+    pool: {}
+    port: 3306
+  resources: {}
+  server: {}
+  storage:
+    cache:
+      volumeSource:
+        emptyDir: {}
+    reports:
+      volumeSource:
+        emptyDir: {}
+  update:
+    githubTokenRef: github-token
+    skip: false
+status:
+  conditions: []
+  message: ""
+  status: ""

--- a/controllers/goharbor/harbor/manifests/trivy/github-token.yaml
+++ b/controllers/goharbor/harbor/manifests/trivy/github-token.yaml
@@ -1,0 +1,11 @@
+apiVersion: goharbor.io/v1alpha2
+kind: Harbor
+metadata:
+  name: example
+  namespace: default
+spec:
+  trivy:
+    githubTokenRef: github-token
+  redis:
+    host: 127.0.0.1
+    port: 3306

--- a/controllers/goharbor/harbor/trivy_test.go
+++ b/controllers/goharbor/harbor/trivy_test.go
@@ -1,0 +1,136 @@
+package harbor_test
+
+import (
+	"context"
+	"os"
+
+	goharborv1alpha2 "github.com/goharbor/harbor-operator/apis/goharbor.io/v1alpha2"
+	"github.com/goharbor/harbor-operator/pkg/controller"
+	"github.com/goharbor/harbor-operator/pkg/graph"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/ovh/configstore"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+func trivyFromResource(r graph.Resource) *goharborv1alpha2.Trivy {
+	res, ok := r.(*controller.Resource)
+	Expect(ok).To(BeTrue())
+
+	u, ok := res.GetResource().(*unstructured.Unstructured)
+	Expect(ok).To(BeTrue())
+
+	var trivy goharborv1alpha2.Trivy
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &trivy)
+	Expect(err).NotTo(HaveOccurred())
+
+	return &trivy
+}
+
+var _ = Describe("Trivy", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = makeContext()
+
+		configstore.DefaultStore = configstore.NewStore()
+	})
+
+	Context("AddTrivyConfigurations", func() {
+		Context("Global github token empty", func() {
+			It("Should pass", func() {
+				r := makeReconciler(ctx)
+
+				h := getSpec("./manifests/trivy/default.yaml")
+
+				_, trivyUpdateSecret, err := r.AddTrivyConfigurations(r.NewContext(ctrl.Request{}), h, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(trivyUpdateSecret).To(BeNil())
+			})
+		})
+
+		Context("Global github token not empty", func() {
+			It("Should pass", func() {
+				os.Setenv(configstore.ConfigEnvVar, "env")
+				os.Setenv("GITHUB_TOKEN", "github-token")
+				configstore.InitFromEnvironment()
+
+				r := makeReconciler(ctx)
+
+				h := getSpec("./manifests/trivy/default.yaml")
+
+				_, trivyUpdateSecret, err := r.AddTrivyConfigurations(r.NewContext(ctrl.Request{}), h, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(trivyUpdateSecret).NotTo(BeNil())
+
+				res, ok := trivyUpdateSecret.(*controller.Resource)
+				Expect(ok).To(BeTrue())
+				Expect(res.GetResource().GetName()).To(BeEquivalentTo("example-harbor-trivy-github"))
+			})
+		})
+	})
+
+	Context("AddTrivy", func() {
+		Context("Github token empty", func() {
+			Context("Trivy update secret is nil", func() {
+				It("Should pass", func() {
+					r := makeReconciler(ctx)
+
+					h := getSpec("./manifests/trivy/default.yaml")
+
+					trivy, err := r.AddTrivy(r.NewContext(ctrl.Request{}), h, nil, nil)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(trivy).NotTo(BeNil())
+
+					t := trivyFromResource(trivy)
+					Expect(t.Spec.Update.GithubTokenRef).To(BeEquivalentTo(""))
+				})
+			})
+
+			Context("Trivy update secret not nil", func() {
+				It("Should pass", func() {
+					os.Setenv(configstore.ConfigEnvVar, "env")
+					os.Setenv("GITHUB_TOKEN", "github-token")
+					configstore.InitFromEnvironment()
+
+					r := makeReconciler(ctx)
+
+					h := getSpec("./manifests/trivy/default.yaml")
+
+					c := r.NewContext(ctrl.Request{}) // this ctx has resource manager
+
+					trivyUpdateSecret, err := r.AddTrivyUpdateSecret(c, h)
+					Expect(err).NotTo(HaveOccurred())
+
+					trivy, err := r.AddTrivy(c, h, nil, trivyUpdateSecret)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(trivy).NotTo(BeNil())
+
+					t := trivyFromResource(trivy)
+					Expect(t.Spec.Update.GithubTokenRef).To(BeEquivalentTo("example-harbor-trivy-github"))
+				})
+			})
+		})
+
+		Context("Github token not empty", func() {
+			It("Should pass", func() {
+				os.Setenv(configstore.ConfigEnvVar, "env")
+				os.Setenv("GITHUB_TOKEN", "github-token")
+				configstore.InitFromEnvironment()
+
+				r := makeReconciler(ctx)
+
+				h := getSpec("./manifests/trivy/github-token.yaml")
+
+				trivy, err := r.AddTrivy(r.NewContext(ctrl.Request{}), h, nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(trivy).NotTo(BeNil())
+
+				t := trivyFromResource(trivy)
+				Expect(t.Spec.Update.GithubTokenRef).To(BeEquivalentTo("github-token"))
+			})
+		})
+	})
+})

--- a/manifests/cluster/patch/github-token.yaml
+++ b/manifests/cluster/patch/github-token.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: harbor-operator
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: GITHUB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: GITHUB_TOKEN

--- a/pkg/controller/resource.go
+++ b/pkg/controller/resource.go
@@ -32,6 +32,10 @@ type Resource struct {
 	resource  resources.Resource
 }
 
+func (res *Resource) GetResource() resources.Resource {
+	return res.resource
+}
+
 func (c *Controller) ProcessFunc(ctx context.Context, resource metav1.Object, dependencies ...graph.Resource) func(context.Context, graph.Resource) error { // nolint:funlen
 	depManager := checksum.New(c.Scheme)
 


### PR DESCRIPTION
1. Inject the github token to the trivy spec when the github token ref
is empty in the spec but github token exists in the operator.
2. Patch the GITHUB_TOKEN from the github actions to the operator in CI.
3. Use helm/kind-action to create k8s cluster.

Signed-off-by: He Weiwei <hweiwei@vmware.com>