### PR TITLE
fix: correct GetImage when the respository is empty

### DIFF
--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -263,7 +263,10 @@ func GetImage(ctx context.Context, component string, options ...Option) (string,
 		return "", fmt.Errorf("unknow component %s", component)
 	}
 
-	repository := strings.TrimSuffix(opts.repository, "/")
+	repository := opts.repository
+	if repository != "" && !strings.HasSuffix(repository, "/") {
+		repository += "/"
+	}
 
-	return fmt.Sprintf("%s/%s:%s%s", repository, imageName, knowCompoents.GetTag(component, opts.harborVersion), opts.tagSuffix), nil
+	return fmt.Sprintf("%s%s:%s%s", repository, imageName, knowCompoents.GetTag(component, opts.harborVersion), opts.tagSuffix), nil
 }

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -124,4 +124,12 @@ var _ = Describe("Get image", func() {
 			Expect(image).To(Equal("goharbor/harbor-core:v2.0.0"))
 		})
 	})
+
+	Describe("Get image for in cluster redis", func() {
+		It("Should pass", func() {
+			image, err := GetImage(ctx, "cluster-redis")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(image).To(Equal("redis:5.0-alpine"))
+		})
+	})
 })


### PR DESCRIPTION
Fix the GetImage function for cluster redis component

Signed-off-by: He Weiwei <hweiwei@vmware.com>