### PR TITLE
feat: add default secuirty context to components

### DIFF
--- a/controllers/goharbor/chartmuseum/deployments.go
+++ b/controllers/goharbor/chartmuseum/deployments.go
@@ -28,7 +28,13 @@ const (
 	DefaultLocalStoragePath               = "/mnt/chartstorage"
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 const (
 	httpsPort = 8443
@@ -303,7 +309,11 @@ func (r *Reconciler) GetDeployment(ctx context.Context, chartMuseum *goharborv1a
 					NodeSelector:                 chartMuseum.Spec.NodeSelector,
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
-
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
+					},
 					Containers: []corev1.Container{{
 						Name:  controllers.ChartMuseum.String(),
 						Image: image,

--- a/controllers/goharbor/core/deployments.go
+++ b/controllers/goharbor/core/deployments.go
@@ -24,7 +24,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 const (
 	healthCheckPeriod                     = 90 * time.Second
@@ -446,6 +452,11 @@ func (r *Reconciler) GetDeployment(ctx context.Context, core *goharborv1alpha2.C
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
+					},
 					Containers: []corev1.Container{{
 						Name:  controllers.Core.String(),
 						Image: image,

--- a/controllers/goharbor/jobservice/deployments.go
+++ b/controllers/goharbor/jobservice/deployments.go
@@ -32,7 +32,13 @@ const (
 	InternalCertificateAuthorityDirectory = "/harbor_cust_cert"
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 const (
 	httpsPort = 8443
@@ -253,6 +259,11 @@ func (r *Reconciler) GetDeployment(ctx context.Context, jobservice *goharborv1al
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
+					},
 					Containers: []corev1.Container{{
 						Name:  controllers.JobService.String(),
 						Image: image,

--- a/controllers/goharbor/notaryserver/deployments.go
+++ b/controllers/goharbor/notaryserver/deployments.go
@@ -27,7 +27,13 @@ const (
 	AuthCertificatePath  = ConfigPath + "/auth-certificates"
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 const apiPort = 4443
 
@@ -172,7 +178,12 @@ func (r *Reconciler) GetDeployment(ctx context.Context, notary *goharborv1alpha2
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
-					InitContainers:               initContainers,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
+					},
+					InitContainers: initContainers,
 					Containers: []corev1.Container{{
 						Name:    controllers.NotaryServer.String(),
 						Image:   image,

--- a/controllers/goharbor/notarysigner/deployments.go
+++ b/controllers/goharbor/notarysigner/deployments.go
@@ -22,7 +22,13 @@ const (
 	HTTPSCertificatePath = ConfigPath + "/certificates"
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 func (r *Reconciler) GetDeployment(ctx context.Context, notary *goharborv1alpha2.NotarySigner) (*appsv1.Deployment, error) { // nolint:funlen
 	getImageOptions := []image.Option{
@@ -128,7 +134,12 @@ func (r *Reconciler) GetDeployment(ctx context.Context, notary *goharborv1alpha2
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
-					InitContainers:               initContainers,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
+					},
+					InitContainers: initContainers,
 					Containers: []corev1.Container{{
 						Name:         controllers.NotarySigner.String(),
 						Image:        image,

--- a/controllers/goharbor/portal/deployments.go
+++ b/controllers/goharbor/portal/deployments.go
@@ -33,7 +33,13 @@ const (
 	httpPort  = 8080
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 func (r *Reconciler) GetDeployment(ctx context.Context, portal *goharborv1alpha2.Portal) (*appsv1.Deployment, error) { // nolint:funlen
 	getImageOptions := []image.Option{
@@ -136,6 +142,11 @@ func (r *Reconciler) GetDeployment(ctx context.Context, portal *goharborv1alpha2
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
+					},
 					Containers: []corev1.Container{
 						{
 							Name:  controllers.Portal.String(),

--- a/controllers/goharbor/registry/deployments.go
+++ b/controllers/goharbor/registry/deployments.go
@@ -36,9 +36,12 @@ const (
 )
 
 var (
-	varFalse          = false
-	varTrue           = true
-	registryUID int64 = 10000
+	varFalse = false
+	varTrue  = true
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
 )
 
 const (
@@ -269,7 +272,9 @@ func (r *Reconciler) GetDeployment(ctx context.Context, registry *goharborv1alph
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
 					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: &registryUID,
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
 					},
 					Containers: []corev1.Container{{
 						Name:  controllers.Registry.String(),

--- a/controllers/goharbor/registryctl/deployments.go
+++ b/controllers/goharbor/registryctl/deployments.go
@@ -31,7 +31,13 @@ const (
 	HealthPath                            = "/api/health"
 )
 
-var varFalse = false
+var (
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
 
 const (
 	httpsPort = 8443
@@ -122,6 +128,12 @@ func (r *Reconciler) GetDeployment(ctx context.Context, registryCtl *goharborv1a
 				},
 			}},
 		},
+	}
+
+	deploy.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+		FSGroup:    &fsGroup,
+		RunAsGroup: &runAsGroup,
+		RunAsUser:  &runAsUser,
 	}
 
 	registryContainer, err := r.getRegistryContainer(deploy)

--- a/controllers/goharbor/trivy/deployments.go
+++ b/controllers/goharbor/trivy/deployments.go
@@ -20,8 +20,11 @@ import (
 )
 
 var (
-	varFalse       = false
-	trivyUID int64 = 10000
+	varFalse = false
+
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
 )
 
 const (
@@ -202,11 +205,11 @@ func (r *Reconciler) GetDeployment(ctx context.Context, trivy *goharborv1alpha2.
 					NodeSelector:                 trivy.Spec.NodeSelector,
 					AutomountServiceAccountToken: &varFalse,
 					Volumes:                      volumes,
-
 					SecurityContext: &corev1.PodSecurityContext{
-						FSGroup: &trivyUID,
+						FSGroup:    &fsGroup,
+						RunAsGroup: &runAsGroup,
+						RunAsUser:  &runAsUser,
 					},
-
 					Containers: []corev1.Container{{
 						Name:  ContainerName,
 						Image: image,

--- a/pkg/cluster/controllers/storage/provision.go
+++ b/pkg/cluster/controllers/storage/provision.go
@@ -19,6 +19,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+var (
+	fsGroup    int64 = 10000
+	runAsGroup int64 = 10000
+	runAsUser  int64 = 10000
+)
+
 func (m *MinIOController) ProvisionMinIOProperties(minioInstamnce *minio.Tenant) (*lcm.CRStatus, error) {
 	properties := &lcm.Properties{}
 
@@ -261,6 +267,11 @@ func (m *MinIOController) generateMinIOCR(ctx context.Context, harborcluster *go
 			},
 		},
 		Spec: minio.TenantSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				FSGroup:    &fsGroup,
+				RunAsGroup: &runAsGroup,
+				RunAsUser:  &runAsUser,
+			},
 			Metadata: &metav1.ObjectMeta{
 				Labels:      m.getLabels(),
 				Annotations: m.generateAnnotations(),


### PR DESCRIPTION
Add default security context to harbor and minio components to let
harbor run in the restricted psp enabled k8s.

Signed-off-by: He Weiwei <hweiwei@vmware.com>