### PR TITLE
feat: watch the crd and owns object after crd ready

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,10 +208,6 @@ jobs:
           exit 1
         fi
 
-        # HACK: restart the harbor-operator pod so that the manager of the harbor cluster can own the redis and postgres types
-        kubectl -n ${operatorNamespace} delete pod -l 'control-plane=harbor-operator'
-        kubectl -n ${operatorNamespace} wait --for=condition=ready pod -l 'control-plane=harbor-operator' --timeout 300s
-
     - name: install harbor
       run: |
         set -ex
@@ -232,8 +228,11 @@ jobs:
           kubectl -n cluster-sample-ns get all
         done
 
-        kubectl -n cluster-sample-ns wait --for=condition=InProgress=False --for=condition=Failed=False harborcluster harborcluster-sample --timeout 600s
-        if [ $? -ne 0 ] ; then
+        function wait-for-condition () {
+          time kubectl -n cluster-sample-ns wait --for=condition=$1 harborcluster harborcluster-sample --timeout $2
+        }
+
+        if ! wait-for-condition InProgress=False 600s && ! wait-for-condition Failed=False 60s; then
           echo install harbor failed
           kubectl get all -n cluster-sample-ns
 

--- a/apis/goharbor.io/v1alpha2/harborcluster_types.go
+++ b/apis/goharbor.io/v1alpha2/harborcluster_types.go
@@ -157,6 +157,8 @@ type HarborClusterStatus struct {
 	// Status can be "unknown", "creating", "healthy" and "unhealthy"
 	Status ClusterStatus `json:"status"`
 
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Revision of the status
 	// Use unix nano
 	Revision int64 `json:"revision"`

--- a/charts/harbor-operator/templates/clusterrole.yaml
+++ b/charts/harbor-operator/templates/clusterrole.yaml
@@ -86,6 +86,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/controllers/goharbor/harborcluster/harborcluster.go
+++ b/controllers/goharbor/harborcluster/harborcluster.go
@@ -14,12 +14,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-const (
-	DefaultWaitCycleTime = 5
-)
-
-var defaultWaitCycle = ctrl.Result{RequeueAfter: DefaultWaitCycleTime * time.Second}
-
 // Reconcile logic of the HarborCluster.
 func (r *Reconciler) Reconcile(req ctrl.Request) (res ctrl.Result, err error) { // nolint:funlen
 	ctx := r.ctrl.NewContext(req)
@@ -117,7 +111,8 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (res ctrl.Result, err error) { 
 	if !st.DependsReady() {
 		r.Log.Info("not all the dependent services are ready")
 
-		return defaultWaitCycle, nil
+		// The controller owns the dependent services so just return directly.
+		return ctrl.Result{}, nil
 	}
 
 	// Create Harbor instance now

--- a/manifests/cluster/deployment.yaml
+++ b/manifests/cluster/deployment.yaml
@@ -3539,6 +3539,9 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               operator:
                 description: ControllerStatus represents the current status of the operator.
                 properties:
@@ -13277,6 +13280,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apps
   resources:

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -1,0 +1,241 @@
+package builder
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func ControllerManagedBy(m manager.Manager) *Builder {
+	crdGetter, err := apiextv1.NewForConfig(m.GetConfig())
+	if err != nil {
+		log.Panic(err)
+	}
+
+	log := m.GetLogger().WithName("builder")
+
+	return &Builder{
+		blder:     ctrl.NewControllerManagedBy(m),
+		crdGetter: crdGetter,
+		log:       log,
+	}
+}
+
+// Builder builds a Controller and it can own objects later when the crd of the object ready.
+type Builder struct {
+	blder *builder.Builder
+
+	ctrl             controller.Controller
+	crdGetter        apiextv1.CustomResourceDefinitionsGetter
+	forObject        runtime.Object
+	log              logr.Logger
+	globalPredicates []predicate.Predicate
+	tryOwnsInputs    []tryOwnsInput
+}
+
+func (blder *Builder) WithLogger(log logr.Logger) *Builder {
+	blder.blder.WithLogger(log)
+	blder.log = log
+
+	return blder
+}
+
+func (blder *Builder) For(object runtime.Object, opts ...builder.ForOption) *Builder {
+	blder.blder.For(object, opts...)
+	blder.forObject = object
+
+	return blder
+}
+
+func (blder *Builder) Owns(object runtime.Object, opts ...builder.OwnsOption) *Builder {
+	blder.blder.Owns(object, opts...)
+
+	return blder
+}
+
+func (blder *Builder) WithEventFilter(p predicate.Predicate) *Builder {
+	blder.blder.WithEventFilter(p)
+	blder.globalPredicates = append(blder.globalPredicates, p)
+
+	return blder
+}
+
+func (blder *Builder) WithOptions(options controller.Options) *Builder {
+	blder.blder.WithOptions(options)
+
+	return blder
+}
+
+// TryOwns owns the object when the crdDependency ready, otherwise try owns it after the crdDependency ready.
+func (blder *Builder) TryOwns(object runtime.Object, crdDependency string, predicates ...predicate.Predicate) *Builder {
+	if isCRDReady(blder.crdGetter, crdDependency) {
+		blder.log.Info("Owns the object directly because the CRD is ready", "crd", crdDependency)
+
+		blder.blder.Owns(object, builder.WithPredicates(predicates...))
+	} else {
+		blder.log.Info("Will try to own the object laster because the CRD is not ready", "crd", crdDependency)
+
+		blder.tryOwnsInputs = append(blder.tryOwnsInputs, tryOwnsInput{
+			object:        object,
+			crdDependency: crdDependency,
+			predicates:    predicates,
+		})
+	}
+
+	return blder
+}
+
+func (blder *Builder) Build(r reconcile.Reconciler) (controller.Controller, error) {
+	var w *tryWatcher
+
+	if len(blder.tryOwnsInputs) > 0 {
+		blder.log.Info("Some objects not owned because the CRDs are not ready, we will watch the CRDs and own the objects when they are ready")
+
+		w = &tryWatcher{
+			crdGetter:        blder.crdGetter,
+			forObject:        blder.forObject,
+			log:              blder.log,
+			globalPredicates: blder.globalPredicates,
+			tryOwnsInputs:    blder.tryOwnsInputs,
+		}
+
+		src := &source.Kind{Type: &v1.CustomResourceDefinition{}}
+		hdler := &handler.Funcs{
+			CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+				w.TryWatch()
+			},
+		}
+
+		blder.blder.Watches(src, hdler)
+	}
+
+	ctrl, err := blder.blder.Build(r)
+	blder.ctrl = ctrl
+
+	// try to watch immediately to avoid the missing events of crd creating during
+	// the Controller building
+	if err == nil && w != nil {
+		w.WithController(ctrl).TryWatch()
+	}
+
+	return ctrl, err
+}
+
+func (blder *Builder) Complete(r reconcile.Reconciler) error {
+	_, err := blder.Build(r)
+
+	return err
+}
+
+type tryOwnsInput struct {
+	object        runtime.Object
+	predicates    []predicate.Predicate
+	crdDependency string
+}
+
+type tryWatcher struct {
+	sync.Mutex
+	watched map[runtime.Object]bool
+
+	ctrl      controller.Controller
+	crdGetter apiextv1.CustomResourceDefinitionsGetter
+	log       logr.Logger
+
+	forObject        runtime.Object
+	globalPredicates []predicate.Predicate
+	tryOwnsInputs    []tryOwnsInput
+}
+
+func (w *tryWatcher) WithController(ctrl controller.Controller) *tryWatcher {
+	w.ctrl = ctrl
+
+	return w
+}
+
+func (w *tryWatcher) TryWatch() {
+	w.Lock()
+	defer w.Unlock()
+
+	if w.ctrl == nil {
+		return
+	}
+
+	if w.watched == nil {
+		w.watched = make(map[runtime.Object]bool, len(w.tryOwnsInputs))
+	}
+
+	for _, own := range w.tryOwnsInputs {
+		if w.watched[own.object] || !isCRDReady(w.crdGetter, own.crdDependency) {
+			continue
+		}
+
+		src := &source.Kind{Type: own.object}
+		hdler := &handler.EnqueueRequestForOwner{
+			OwnerType:    w.forObject,
+			IsController: true,
+		}
+
+		allPredicates := append([]predicate.Predicate(nil), w.globalPredicates...)
+		allPredicates = append(allPredicates, own.predicates...)
+
+		if err := w.ctrl.Watch(src, hdler, allPredicates...); err != nil {
+			w.log.Error(err, "Watch Source Failed", "crd", own.crdDependency)
+		} else {
+			w.log.Info("Watch Source Success", "crd", own.crdDependency)
+			w.watched[own.object] = true
+		}
+	}
+}
+
+func isCRDReady(getter apiextv1.CustomResourceDefinitionsGetter, name string) bool {
+	log := ctrl.Log.Logger.WithName("builder")
+
+	crdReadyWaitInterval := time.Second * 10 // nolint:gomnd
+	crdReadyWaitTimeout := time.Minute * 5   // nolint:gomnd
+
+	// retry to checking the CRD every 10 seconds when it found but not established during 5 minutes
+	err := wait.PollImmediate(crdReadyWaitInterval, crdReadyWaitTimeout, func() (bool, error) {
+		c, err := getter.CustomResourceDefinitions().Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			return false, err // not found, poll will return immediately
+		}
+
+		for _, cond := range c.Status.Conditions {
+			switch cond.Type { // nolint:exhaustive
+			case v1.Established:
+				if cond.Status == v1.ConditionTrue {
+					return true, nil // crd is established，poll will return immediately
+				}
+			case v1.NamesAccepted:
+				if cond.Status == v1.ConditionFalse {
+					return false, fmt.Errorf("name conflict: %v", cond.Reason) // conflicted, poll will return immediately
+				}
+			}
+		}
+
+		log.Info("CRD found but not established, retry to check again after 10 seconds", "crd", name)
+
+		return false, nil
+	})
+
+	return err == nil
+}

--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	postgresv1 "github.com/zalando/postgres-operator/pkg/apis/acid.zalan.do/v1"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 )
@@ -56,6 +57,11 @@ func New(ctx context.Context) (*runtime.Scheme, error) {
 	err = minio.AddToScheme(scheme)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to configure minio scheme")
+	}
+
+	err = apiextensions.AddToScheme(scheme)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to configure apiextensions scheme")
 	}
 
 	// +kubebuilder:scaffold:scheme


### PR DESCRIPTION
In the first time harbor operator running, the `postgresql` and `redisfailover` CRDs are not created at the harbor operator manager bootstrap stage, harbor cluster controller will be failed when it owns the postgresql and redisfailover. The controller can't get the notification from the status changing of `postgresql` and `redisfailover`.

This PR will watch the CRD and try to own the objects again after a CRD ready.

Signed-off-by: He Weiwei <hweiwei@vmware.com>