### PR TITLE
fix: remove redis tls spec and set keepPVC as false

### DIFF
--- a/apis/goharbor.io/v1alpha3/harborcluster_types.go
+++ b/apis/goharbor.io/v1alpha3/harborcluster_types.go
@@ -55,10 +55,6 @@ type RedisSpec struct {
 	// Default is 10 connections per every CPU as reported by runtime.NumCPU.
 	PoolSize int `json:"poolSize,omitempty"`
 
-	// TLS Config to use. When set TLS will be negotiated.
-	// set the secret which type of Opaque, and contains "tls.key","tls.crt","ca.crt".
-	TLSConfig string `json:"tlsConfig,omitempty"`
-
 	GroupName string `json:"groupName,omitempty"`
 
 	Hosts []RedisHosts `json:"hosts,omitempty"`

--- a/manifests/cluster/deployment.yaml
+++ b/manifests/cluster/deployment.yaml
@@ -2545,9 +2545,6 @@ spec:
                           storageClassName:
                             type: string
                         type: object
-                      tlsConfig:
-                        description: TLS Config to use. When set TLS will be negotiated. set the secret which type of Opaque, and contains "tls.key","tls.crt","ca.crt".
-                        type: string
                     type: object
                 required:
                 - kind

--- a/pkg/cluster/controllers/cache/resource_manager.go
+++ b/pkg/cluster/controllers/cache/resource_manager.go
@@ -72,8 +72,6 @@ func (rm *redisResourceManager) WithCluster(cluster *goharborv1.HarborCluster) R
 func (rm *redisResourceManager) GetCacheCR(ctx context.Context, harborcluster *goharborv1.HarborCluster) (runtime.Object, error) {
 	resource := rm.GetResourceList()
 	pvc, _ := GenerateStoragePVC(rm.GetStorageClass(), rm.cluster.Name, rm.GetStorageSize(), rm.GetLabels())
-	// keep pvc after cr deleted.
-	keepPVCAfterDeletion := true
 
 	image, err := rm.GetImage(ctx, harborcluster)
 	if err != nil {
@@ -99,7 +97,6 @@ func (rm *redisResourceManager) GetCacheCR(ctx context.Context, harborcluster *g
 				},
 				Storage: redisOp.RedisStorage{
 					PersistentVolumeClaim: pvc,
-					KeepAfterDeletion:     keepPVCAfterDeletion,
 				},
 				Image:            image,
 				ImagePullPolicy:  rm.getImagePullPolicy(ctx, harborcluster),


### PR DESCRIPTION
1. Remove harbor cluster spec redis tlsConfig.
2. Remove set redis keepPVC true as default.

Signed-off-by: chlins <chlins.zhang@gmail.com>