### PR TITLE
fix: append slash to the end of ingress path

### DIFF
--- a/controllers/goharbor/harbor/ingresses.go
+++ b/controllers/goharbor/harbor/ingresses.go
@@ -254,23 +254,23 @@ func (r *Reconciler) GetCoreIngressRuleValue(ctx context.Context, harbor *goharb
 				PathType: &pathTypePrefix,
 				Backend:  portal,
 			}, {
-				Path:     "/api",
+				Path:     "/api/",
 				PathType: &pathTypePrefix,
 				Backend:  core,
 			}, {
-				Path:     "/service",
+				Path:     "/service/",
 				PathType: &pathTypePrefix,
 				Backend:  core,
 			}, {
-				Path:     "/v2",
+				Path:     "/v2", // distribution APIs will request to `/v2` so don't append slash for this ingress path
 				PathType: &pathTypePrefix,
 				Backend:  core,
 			}, {
-				Path:     "/chartrepo",
+				Path:     "/chartrepo/",
 				PathType: &pathTypePrefix,
 				Backend:  core,
 			}, {
-				Path:     "/c",
+				Path:     "/c/",
 				PathType: &pathTypePrefix,
 				Backend:  core,
 			}},


### PR DESCRIPTION
There is a js file named `common.es-2015.xxx.js` in the portal of the
harbor 2.3.0, the request of this file will be transported to the core
component when there isn't a slash at the end of the ingress path,
the portal will not be accessible. So we need to append a slash to the end
of the ingress path.

Signed-off-by: He Weiwei <hweiwei@vmware.com>