### PR TITLE
doc(Development): Remove cert-manager deployment

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -30,15 +30,6 @@ make dev-tools
 ### Services
 
 - [Kubernetes cluster](https://kubernetes.io). You can order a Kubernetes cluster on [ovh.com](https://www.ovh.com/fr/public-cloud/kubernetes/). Then configure your environment to have the right [`Kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/).
-- [CertManager](https://cert-manager.io/docs/installation/kubernetes/#steps) >= 0.11
-
-  ```bash
-  helm install cert-manager \
-    --namespace cert-manager \
-    --version v0.12.0 \
-    jetstack/cert-manager
-  ```
-
 - Jaeger server.
   
   ```bash


### PR DESCRIPTION
Hello,

I think we can remove this cert manager command because it causes issues when running the _run_ Makefile target that tries to launch cert-manager too but on a more recent version. I think we should let the _run_ target handle this.

Signed-off-by: Thomas Coudert thomas.coudert@ovhcloud.com