### PR TITLE
fix: let backend port in notary ingress depend on internal tls

### DIFF
--- a/controllers/goharbor/harbor/ingresses.go
+++ b/controllers/goharbor/harbor/ingresses.go
@@ -7,7 +7,6 @@ import (
 	goharborv1 "github.com/goharbor/harbor-operator/apis/goharbor.io/v1beta1"
 	harbormetav1 "github.com/goharbor/harbor-operator/apis/meta/v1alpha1"
 	"github.com/goharbor/harbor-operator/controllers"
-	"github.com/goharbor/harbor-operator/controllers/goharbor/notaryserver"
 	"github.com/goharbor/harbor-operator/pkg/graph"
 	"github.com/pkg/errors"
 	netv1 "k8s.io/api/networking/v1"
@@ -149,7 +148,7 @@ func (r *Reconciler) GetNotaryIngressRules(ctx context.Context, harbor *goharbor
 		Service: &netv1.IngressServiceBackend{
 			Name: r.NormalizeName(ctx, harbor.GetName(), controllers.NotaryServer.String()),
 			Port: netv1.ServiceBackendPort{
-				Number: notaryserver.PublicPort,
+				Number: harbor.Spec.InternalTLS.GetInternalPort(harbormetav1.NotaryServerTLS),
 			},
 		},
 	}

--- a/controllers/goharbor/notaryserver/services.go
+++ b/controllers/goharbor/notaryserver/services.go
@@ -10,10 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-const (
-	PublicPort = 443
-)
-
 func (r *Reconciler) GetService(ctx context.Context, notary *goharborv1.NotaryServer) (*corev1.Service, error) {
 	name := r.NormalizeName(ctx, notary.GetName())
 	namespace := notary.GetNamespace()


### PR DESCRIPTION
Closes #736

Signed-off-by: He Weiwei <hweiwei@vmware.com>