### PR TITLE
fix(Makefile): Set default ingress class when installing nginx-ingres…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -455,7 +455,8 @@ ingress: helm
 	$(HELM) repo add ingress-nginx https://kubernetes.github.io/ingress-nginx # https://github.com/kubernetes/ingress-nginx/tree/master/charts/ingress-nginx#get-repo-info
 	$(HELM) upgrade --install nginx ingress-nginx/ingress-nginx \
 		--namespace $(INGRESS_NAMESPACE) \
-		--set-string controller.config.proxy-body-size=0
+		--set-string controller.config.proxy-body-size=0 \
+		--set-string controller.ingressClassResource.default=true
 
 CERTMANAGER_NAMESPACE := cert-manager
 


### PR DESCRIPTION
Hello,

We need to set a default ingress class, else harbor and notary ingresses are not working.

Signed-off-by: Thomas Coudert thomas.coudert@ovhcloud.com