### PR TITLE
chore: build controller-gen and stringer in temp dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -520,9 +520,15 @@ controller-gen:
 $(CONTROLLER_GEN):
 	$(MAKE) $(BIN)
 	# https://github.com/kubernetes-sigs/controller-tools/tree/master/cmd/controller-gen
-	go get 'sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_GEN_VERSION)'
-	go build -mod=readonly -o $(CONTROLLER_GEN) sigs.k8s.io/controller-tools/cmd/controller-gen
-	go mod tidy
+	@{ \
+	set -e ;\
+	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
+	cd $$CONTROLLER_GEN_TMP_DIR ;\
+	go mod init tmp ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v$(CONTROLLER_GEN_VERSION) ;\
+	go build -mod=readonly -o $(CONTROLLER_GEN) sigs.k8s.io/controller-tools/cmd/controller-gen ;\
+	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	}
 
 # find or download markdownlint
 # download markdownlint if necessary
@@ -640,9 +646,15 @@ stringer:
 $(STRINGER):
 	$(MAKE) $(BIN)
 	# https://pkg.go.dev/golang.org/x/tools/cmd/stringer
-	go get 'golang.org/x/tools/cmd/stringer@$(STRINGER_VERSION)'
-	go build -mod=readonly -o $(STRINGER) golang.org/x/tools/cmd/stringer
-	go mod tidy
+	@{ \
+	set -e ;\
+	STRINGER_TMP_DIR=$$(mktemp -d) ;\
+	cd $$STRINGER_TMP_DIR ;\
+	go mod init tmp ;\
+	go get golang.org/x/tools/cmd/stringer@$(STRINGER_VERSION) ;\
+	go build -mod=readonly -o $(STRINGER) golang.org/x/tools/cmd/stringer ;\
+	rm -rf $$STRINGER_TMP_DIR ;\
+	}
 
 # find or download hadolint
 # download hadolint if necessary

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-kit/kit v0.10.0
 	github.com/go-logr/logr v0.4.0
 	github.com/go-redis/redis v6.15.9+incompatible
-	github.com/goharbor/harbor/src v0.0.0-20211112031241-d260e632d85c
+	github.com/goharbor/harbor/src v0.0.0-20211025104526-d4affc2eba6d
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/jaegertracing/jaeger-lib v2.2.0+incompatible
 	github.com/jetstack/cert-manager v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -496,8 +496,8 @@ github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/goharbor/harbor/src v0.0.0-20211112031241-d260e632d85c h1:a2/EtiS4G9YCoKVoslPdzAhAP8/skePzqlEraWrt1Jc=
-github.com/goharbor/harbor/src v0.0.0-20211112031241-d260e632d85c/go.mod h1:5WKePD4Y8lsPoD5xQy887gFC97EC6vNbJVBcbva/8ws=
+github.com/goharbor/harbor/src v0.0.0-20211025104526-d4affc2eba6d h1:/ZsWt+7vAimZd7g0P7JMoy5gc/QO6qf6HV2cPsGPHCU=
+github.com/goharbor/harbor/src v0.0.0-20211025104526-d4affc2eba6d/go.mod h1:5WKePD4Y8lsPoD5xQy887gFC97EC6vNbJVBcbva/8ws=
 github.com/goji/httpauth v0.0.0-20160601135302-2da839ab0f4d/go.mod h1:nnjvkQ9ptGaCkuDUx6wNykzzlUixGxvkme+H/lnzb+A=
 github.com/golang-jwt/jwt/v4 v4.1.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-migrate/migrate/v4 v4.11.0/go.mod h1:nqbpDbckcYjsCD5I8q5+NI9Tkk7SVcmaF40Ax1eAWhg=


### PR DESCRIPTION
Build the controller-gen and stringer in temp dir to avoid the version of harbor pkg always changing in github actions.

Signed-off-by: He Weiwei <hweiwei@vmware.com>