### PR TITLE
[Backport] fix: Allow for empty S3 SecretKeyRef

### DIFF
--- a/controllers/goharbor/registry/deployments.go
+++ b/controllers/goharbor/registry/deployments.go
@@ -318,17 +318,19 @@ func (r *Reconciler) ApplyFilesystemStorageEnvs(ctx context.Context, registry *g
 func (r *Reconciler) ApplyS3StorageEnvs(ctx context.Context, registry *goharborv1.Registry, deploy *appsv1.Deployment) error {
 	regContainer := &deploy.Spec.Template.Spec.Containers[registryContainerIndex]
 
-	regContainer.Env = append(regContainer.Env, corev1.EnvVar{
-		Name: "REGISTRY_STORAGE_S3_SECRETKEY",
-		ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				Key: harbormetav1.SharedSecretKey,
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: registry.Spec.Storage.Driver.S3.SecretKeyRef,
+	if registry.Spec.Storage.Driver.S3.SecretKeyRef != "" {
+		regContainer.Env = append(regContainer.Env, corev1.EnvVar{
+			Name: "REGISTRY_STORAGE_S3_SECRETKEY",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					Key: harbormetav1.SharedSecretKey,
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: registry.Spec.Storage.Driver.S3.SecretKeyRef,
+					},
 				},
 			},
-		},
-	})
+		})
+	}
 
 	return nil
 }


### PR DESCRIPTION
This PR backports #811 to the 1.1.x release branch, so that it can be released as a fix.

Here is a working container image: ghcr.io/sagikazarmark/harbor-operator:v1.1.2-custom.1