### PR TITLE
use fixed postgresql/redis image in go tests

### DIFF
--- a/controllers/goharbor/internal/test/postgresql/postgres.go
+++ b/controllers/goharbor/internal/test/postgresql/postgres.go
@@ -103,7 +103,7 @@ func New(ctx context.Context, ns string, databases ...string) harbormetav1.Postg
 					},
 					Containers: []corev1.Container{{
 						Name:  "database",
-						Image: "bitnami/postgresql",
+						Image: "bitnami/postgresql:13.6.0",
 						Env: []corev1.EnvVar{
 							{
 								Name: "POSTGRESQL_PASSWORD",

--- a/controllers/goharbor/internal/test/redis/redis.go
+++ b/controllers/goharbor/internal/test/redis/redis.go
@@ -72,7 +72,7 @@ func New(ctx context.Context, ns string) harbormetav1.RedisConnection {
 					}},
 					Containers: []corev1.Container{{
 						Name:  "redis",
-						Image: "bitnami/redis",
+						Image: "bitnami/redis:6.2.6",
 						Env: []corev1.EnvVar{{
 							Name: "REDIS_PASSWORD",
 							ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
CI "Go tests" is failing, that NotaryServer and NotarySigner pods fail to start
This is because notary binary can't connect to lasted postgres version 14.2 with docker image bitnami/postgresql
So use fixed version for postgres and redis
