### PR TITLE
Fix type in Chart.yaml

### DIFF
--- a/charts/harbor-operator/Chart.yaml
+++ b/charts/harbor-operator/Chart.yaml
@@ -28,7 +28,7 @@ dependencies:
     - storage
 - name: redis-operator
   version: 3.1.4
-  condition: rediso-perator.enabled
+  condition: redis-operator.enabled
   repository: https://spotahome.github.io/redis-operator
   tags:
     - cache


### PR DESCRIPTION
There was a type with the variable used for defining whether the Redis-operator should be used or not.