### PR TITLE
Too long: must have at most 262144 bytes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,7 @@ jobs:
         kustomize edit add secret github-token --disableNameSuffixHash --from-literal=GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
         kustomize edit add patch --path patch/github-token.yaml
         kustomize edit set image goharbor/harbor-operator=${dockerImage}
-        kustomize build | kubectl apply -f -
+        kustomize build | kubectl create -f -
 
         if ! time kubectl -n ${operatorNamespace} wait --for=condition=Available deployment --all --timeout 300s; then
           kubectl get all -n ${operatorNamespace}
@@ -420,7 +420,7 @@ jobs:
           kustomize edit add secret github-token --disableNameSuffixHash --from-literal=GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           kustomize edit add patch --path patch/github-token.yaml
           kustomize edit set image goharbor/harbor-operator=${dockerImage}
-          kustomize build | kubectl apply -f -
+          kustomize build | kubectl create -f -
 
           if ! time kubectl -n ${operatorNamespace} wait --for=condition=Available deployment --all --timeout 300s; then
             kubectl get all -n ${operatorNamespace}

--- a/manifests/cluster/kustomization.yaml
+++ b/manifests/cluster/kustomization.yaml
@@ -15,8 +15,8 @@ commonAnnotations:
 resources:
   - ../../config/default # harbor operator
   - patch/namespace.yaml
-  - https://raw.githubusercontent.com/spotahome/redis-operator/master/example/operator/all-redis-operator-resources.yaml?ref=v1.1.1 # redis operator
-  - https://raw.githubusercontent.com/spotahome/redis-operator/master/manifests/databases.spotahome.com_redisfailovers.yaml?ref=v1.1.1 # redis operator crd
+  - https://raw.githubusercontent.com/spotahome/redis-operator/v1.1.1/example/operator/all-redis-operator-resources.yaml # redis operator
+  - https://raw.githubusercontent.com/spotahome/redis-operator/v1.1.1/manifests/databases.spotahome.com_redisfailovers.yaml # redis operator crd
   - github.com/zalando/postgres-operator/manifests?ref=v1.6.3 # postgresql operator
   - github.com/minio/operator?ref=v4.4.28 # minIO storage operator
 


### PR DESCRIPTION
Because current redis operator CRD too long, use `kubectl apply` executer fail， use `kubectl create` can success.

> The CustomResourceDefinition "redisfailovers.databases.spotahome.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes

ci: https://github.com/goharbor/harbor-operator/runs/8192620687?check_suite_focus=true

Signed-off-by: rongfu.leng <1275177125@qq.com>