### PR TITLE
fix: postgresql not deleted with harborcluster (1.4.0)

### DIFF
--- a/pkg/cluster/controllers/database/update.go
+++ b/pkg/cluster/controllers/database/update.go
@@ -35,6 +35,8 @@ func (p *PostgreSQLController) Update(ctx context.Context, harborcluster *goharb
 		FromUnstructured(expectUnstructuredCR.UnstructuredContent(), &expectCR); err != nil {
 		return databaseNotReadyStatus(DefaultUnstructuredConverterError, err.Error()), err
 	}
+	
+	expectCR.SetOwnerReferences(actualCR.GetOwnerReferences())
 
 	if !common.Equals(ctx, p.Scheme, harborcluster, &actualCR) {
 		p.Log.Info(


### PR DESCRIPTION
add ownerReference to expectCR in PostgreSQLController.Update before comparing. Origin expectCR have no OwnerReference .