### PR TITLE
fix(class): Don't reconcile when harbor-class changed

### DIFF
--- a/pkg/event-filter/class/class.go
+++ b/pkg/event-filter/class/class.go
@@ -22,7 +22,7 @@ func (cf *Filter) Delete(e event.DeleteEvent) bool {
 
 // Update returns true if the Update event should be processed.
 func (cf *Filter) Update(e event.UpdateEvent) bool {
-	return cf.HarborClassAnnotationMatch(e.ObjectOld) || cf.HarborClassAnnotationMatch(e.ObjectNew)
+	return cf.HarborClassAnnotationMatch(e.ObjectNew)
 }
 
 // Generic returns true if the Generic event should be processed.

--- a/pkg/event-filter/class/class_test.go
+++ b/pkg/event-filter/class/class_test.go
@@ -302,7 +302,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 					})
@@ -368,7 +368,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 					})
@@ -434,7 +434,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 					})
@@ -1079,7 +1079,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 
@@ -1092,7 +1092,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 
@@ -1105,7 +1105,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 
@@ -1118,7 +1118,7 @@ var _ = Describe("class-filter", func() {
 
 							It("Should match", func() {
 								ok := cf.Update(event.UpdateEvent{ObjectOld: oldResource, ObjectNew: newResource})
-								Expect(ok).To(BeTrue())
+								Expect(ok).To(BeFalse())
 							})
 						})
 


### PR DESCRIPTION
Hello,

When changing Harbor custom resource annotation `goharbor.io/harbor-class` from class-1 to class-2, operator managing class-1 still reconcile custom resource in same time than harbor-operator managing class-2, so operators are both modifying resources in same time breaking everything.
I don't see why operator should still reconcile resources not handled by its harbor class anymore.

Thomas