### PR TITLE
fix: set jobservice workercount in configmap

### DIFF
--- a/config/config/assets/jobservice-config.yaml.tmpl
+++ b/config/config/assets/jobservice-config.yaml.tmpl
@@ -16,7 +16,7 @@ port: 8080
 
 worker_pool:
   backend: "redis"
-
+  workers: {{ .Spec.WorkerPool.WorkerCount }}
   redis_pool:
 {{- if .Spec.WorkerPool.Redis.PasswordRef }}
     redis_url: {{ "redis-password" | secretData .Spec.WorkerPool.Redis.PasswordRef | .Spec.WorkerPool.Redis.GetDSN }}

--- a/manifests/cluster/deployment.yaml
+++ b/manifests/cluster/deployment.yaml
@@ -63496,7 +63496,7 @@ data:
 
     worker_pool:
       backend: "redis"
-
+      workers: {{ .Spec.WorkerPool.WorkerCount }}
       redis_pool:
     {{- if .Spec.WorkerPool.Redis.PasswordRef }}
         redis_url: {{ "redis-password" | secretData .Spec.WorkerPool.Redis.PasswordRef | .Spec.WorkerPool.Redis.GetDSN }}

--- a/manifests/harbor/deployment.yaml
+++ b/manifests/harbor/deployment.yaml
@@ -41716,7 +41716,7 @@ data:
 
     worker_pool:
       backend: "redis"
-
+      workers: {{ .Spec.WorkerPool.WorkerCount }}
       redis_pool:
     {{- if .Spec.WorkerPool.Redis.PasswordRef }}
         redis_url: {{ "redis-password" | secretData .Spec.WorkerPool.Redis.PasswordRef | .Spec.WorkerPool.Redis.GetDSN }}


### PR DESCRIPTION
Until now, when setting a custom value for `spec.jobservice.workerCount` in the `HarborCluster` CustomResource, the change is not reflected in the managed harbor instance. This is because the corresponding key in the jobservice's config file (see https://github.com/goharbor/harbor-helm/blob/master/templates/jobservice/jobservice-cm.yaml#L18)  doesn't get set by the operator.

This PR fixes this by setting the value for `worker_pool.workers` in  `config/config/assets/jobservice-config.yaml.tmpl`.