### PR TITLE
Add the missing github-cr proxy cache module

### DIFF
--- a/controllers/goharbor/core/deployments.go
+++ b/controllers/goharbor/core/deployments.go
@@ -65,6 +65,7 @@ func getDefaultAllowedRegistryTypesForProxyCache() string {
 		registry.RegistryTypeHarbor,
 		registry.RegistryTypeAzureAcr,
 		registry.RegistryTypeAwsEcr,
+		registry.RegistryTypeGithubCR,
 		registry.RegistryTypeGoogleGcr,
 		registry.RegistryTypeQuay,
 		registry.RegistryTypeDockerRegistry,


### PR DESCRIPTION
The github-cr was missing from the options therefore it was added.