### PR TITLE
Allow redis password contains special characters

### DIFF
--- a/controllers/goharbor/core/secrets.go
+++ b/controllers/goharbor/core/secrets.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	goharborv1 "github.com/goharbor/harbor-operator/apis/goharbor.io/v1beta1"
 	harbormetav1 "github.com/goharbor/harbor-operator/apis/meta/v1alpha1"
@@ -41,8 +42,8 @@ func (r *Reconciler) GetSecret(ctx context.Context, core *goharborv1.Core) (*cor
 
 		redisPassword = string(password)
 	}
-
-	coreCacheDSN := core.Spec.Redis.GetDSNStringWithRawPassword(redisPassword)
+	// support redis password contains special character by using url.QueryEscape
+	coreCacheDSN := core.Spec.Redis.GetDSNStringWithRawPassword(url.QueryEscape(redisPassword))
 
 	var registryPassword string
 
@@ -64,8 +65,8 @@ func (r *Reconciler) GetSecret(ctx context.Context, core *goharborv1.Core) (*cor
 
 		registryPassword = string(password)
 	}
-
-	registryCacheDSN := core.Spec.Components.Registry.Redis.GetDSNStringWithRawPassword(registryPassword)
+	// support redis password contains special character by using url.QueryEscape
+	registryCacheDSN := core.Spec.Components.Registry.Redis.GetDSNStringWithRawPassword(url.QueryEscape(registryPassword))
 
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/controllers/goharbor/exporter/deployments.go
+++ b/controllers/goharbor/exporter/deployments.go
@@ -275,8 +275,8 @@ func (r *Reconciler) getJobServiceRedisURL(ctx context.Context, exporter *goharb
 	if redisPassword == "" {
 		logger.Get(ctx).Info("redis password secret of jobservice not found", "secret", exporter.Spec.JobService.Redis.PasswordRef)
 	}
-
-	return exporter.Spec.JobService.Redis.GetDSNStringWithRawPassword(redisPassword), nil
+	// support redis password contains special character by using url.QueryEscape
+	return exporter.Spec.JobService.Redis.GetDSNStringWithRawPassword(url.QueryEscape(redisPassword)), nil
 }
 
 func (r *Reconciler) getValueFromSecret(ctx context.Context, namespace, name, key string) (string, error) {


### PR DESCRIPTION
fix: https://github.com/goharbor/harbor-operator/issues/1054

```
## core && registry 
ubuntu@miner:~$ kubectl get secret harborcluster-sample-harbor-harbor-core -n test -o yaml | grep REDIS
  _REDIS_URL_CORE: cmVkaXM6Ly86T2RMNTFGVnpUaCU0MFIlMjUlNUUlNDBAMTAuMTg2LjU1LjM1OjYzNzkvMD9pZGxlX3RpbWVvdXRfc2Vjb25kcz0zMA==
  _REDIS_URL_REG: cmVkaXM6Ly86T2RMNTFGVnpUaCU0MFIlMjUlNUUlNDBAMTAuMTg2LjU1LjM1OjYzNzkvMT9pZGxlX3RpbWVvdXRfc2Vjb25kcz0zMA==

## exporter for jobservice
kubectl get deployment.apps/harborcluster-sample-harbor-harbor-exporter -n test -o yaml
...
- name: HARBOR_REDIS_URL
          value: redis://:OdL51FVzTh%40R%25%5E%40@10.186.55.35:6379/2

## trivy, no need to escape special character due to using different function GetDSN()
ubuntu@miner:~$ kubectl get secret harborcluster-sample-harbor-harbor-trivy -n test -o yaml | grep REDIS
  SCANNER_JOB_QUEUE_REDIS_URL: cmVkaXM6Ly86T2RMNTFGVnpUaCU0MFIlMjUlNUUlNDBAMTAuMTg2LjU1LjM1OjYzNzkvNQ==
  SCANNER_REDIS_URL: cmVkaXM6Ly86T2RMNTFGVnpUaCU0MFIlMjUlNUUlNDBAMTAuMTg2LjU1LjM1OjYzNzkvNQ==
  SCANNER_STORE_REDIS_URL: cmVkaXM6Ly86T2RMNTFGVnpUaCU0MFIlMjUlNUUlNDBAMTAuMTg2LjU1LjM1OjYzNzkvNQ==

## distribution using harbor-redis password directly, no need to change
- name: REGISTRY_REDIS_PASSWORD
          valueFrom:
            secretKeyRef:
              key: redis-password
              name: harbor-redis
              optional: true

## chartmuseum using harbor-redis password directly, no need to change
- name: CACHE_REDIS_PASSWORD
          valueFrom:
            secretKeyRef:
              key: redis-password
              name: harbor-redis
              optional: false
```

```
const (
	coreRedisDatabaseIndex        = 0
	registryRedisDatabaseIndex    = 1
	jobServiceRedisDatabaseIndex  = 2
	chartMuseumRedisDatabaseIndex = 3
	trivyRedisDatabaseIndex       = 5
)
```
