### PR TITLE
fix: postgresql not deleted with harborcluster

### DIFF
--- a/pkg/cluster/controllers/database/update.go
+++ b/pkg/cluster/controllers/database/update.go
@@ -36,6 +36,8 @@ func (p *PostgreSQLController) Update(ctx context.Context, harborcluster *goharb
 		return databaseNotReadyStatus(DefaultUnstructuredConverterError, err.Error()), err
 	}
 
+	expectCR.SetOwnerReferences(actualCR.GetOwnerReferences())
+
 	if !common.Equals(ctx, p.Scheme, harborcluster, &actualCR) {
 		p.Log.Info(
 			"Update Database resource",


### PR DESCRIPTION
This CL is from https://github.com/goharbor/harbor-operator/pull/1014 which adds ownerReference to expectCR in PostgreSQLController.Update before comparing. Origin expectCR have no OwnerReference.